### PR TITLE
Fix permissions issue saving iptables

### DIFF
--- a/datafiles/helper.sh
+++ b/datafiles/helper.sh
@@ -127,7 +127,7 @@ iptables_configure() {
     sudo iptables -I INPUT -p icmp --icmp-type destination-unreachable -j ACCEPT
     sudo iptables -I INPUT -p icmp --icmp-type source-quench -j ACCEPT
     sudo iptables -I INPUT -p icmp --icmp-type time-exceeded -j ACCEPT
-    sudo iptables-save > /etc/iptables/rules.v4
+    sudo bash -c 'iptables-save > /etc/iptables/rules.v4'
 }
 
 configure_flask () {


### PR DESCRIPTION
When running `skale node init...` as a sudo user there can be an issue writing the `iptables-save` data to the ` /etc/iptables/rules.v4` file as the sudo does not carry over to the file write.