### PR TITLE
Wrap mysql credentials for cli use in quotes

### DIFF
--- a/core/mysql_backup.py
+++ b/core/mysql_backup.py
@@ -25,7 +25,7 @@ def mysql_creds_for_cmd(env_filepath: str) -> str:
     :rtype: str
     """
     env_params = extract_env_params(env_filepath)
-    return f'-u {env_params["DB_USER"]} -p{env_params["DB_PASSWORD"]}'
+    return f'-u \'{env_params["DB_USER"]}\' -p\'{env_params["DB_PASSWORD"]}\''
 
 
 def create_mysql_backup(env_filepath: str) -> bool:


### PR DESCRIPTION
This allows one to use reserved shell characters like '*' in
username and passwords. Without this change the shell would
interpret and expand those characters.