### PR TITLE
Skale node backup command update

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -111,7 +111,7 @@ Optional variables:
 Restore SKALE node on another machine
 
 ```shell
-skale node restore [BACKUP_PATH] [ENV_FILE]
+skale node restore [BACKUP_PATH]
 ```
 
 Arguments:
@@ -124,7 +124,7 @@ Arguments:
 Generate backup file to restore SKALE node on another machine
 
 ```shell
-skale node backup [BACKUP_FOLDER_PATH] [ENV_FILE]
+skale node backup [BACKUP_FOLDER_PATH]
 ```
 
 Arguments:


### PR DESCRIPTION
In the latest CLI, the node backup and restore command doesn't need .env file as a parameter.