### PR TITLE
Remove --catchup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,7 +560,6 @@ Options:
 
 -   `--archive` - Run sync node in an archive node (disable block rotation)
 -   `--historic-state` - Enable historic state (works only in pair with --archive flag)
--   `--catchup` - Add a flag to start sync node in catchup mode
 
 #### Sync node update
 

--- a/node_cli/cli/sync_node.py
+++ b/node_cli/cli/sync_node.py
@@ -54,11 +54,6 @@ def sync_node():
     is_flag=True
 )
 @click.option(
-    '--catchup',
-    help=TEXTS['init']['catchup'],
-    is_flag=True
-)
-@click.option(
     '--historic-state',
     help=TEXTS['init']['historic_state'],
     is_flag=True
@@ -71,13 +66,13 @@ def sync_node():
     help='Ip of the node from to download snapshot from'
 )
 @streamed_cmd
-def _init_sync(env_file, archive, catchup, historic_state, snapshot_from: Optional[str]):
+def _init_sync(env_file, archive, historic_state, snapshot_from: Optional[str]):
     if historic_state and not archive:
         error_exit(
             '--historic-state can be used only is combination with --archive',
             exit_code=CLIExitCodes.FAILURE
         )
-    init_sync(env_file, archive, catchup, historic_state, snapshot_from)
+    init_sync(env_file, archive, historic_state, snapshot_from)
 
 
 @sync_node.command('update', help='Update sync node from .env file')
@@ -107,11 +102,6 @@ def _update_sync(env_file, unsafe_ok):
     is_flag=True
 )
 @click.option(
-    '--catchup',
-    help=TEXTS['init']['catchup'],
-    is_flag=True
-)
-@click.option(
     '--historic-state',
     help=TEXTS['init']['historic_state'],
     is_flag=True
@@ -126,13 +116,11 @@ def _update_sync(env_file, unsafe_ok):
 @streamed_cmd
 def _repair_sync(
     archive: str,
-    catchup: str,
     historic_state: str,
     snapshot_from: Optional[str] = None
 ) -> None:
     repair_sync(
         archive=archive,
-        catchup=catchup,
         historic_state=historic_state,
         snapshot_from=snapshot_from
     )

--- a/node_cli/core/node.py
+++ b/node_cli/core/node.py
@@ -186,7 +186,6 @@ def restore(backup_path, env_filepath, no_snapshot=False, config_only=False):
 def init_sync(
     env_filepath: str,
     archive: bool,
-    catchup: bool,
     historic_state: bool,
     snapshot_from: str
 ) -> None:
@@ -198,7 +197,6 @@ def init_sync(
         env_filepath,
         env,
         archive,
-        catchup,
         historic_state,
         snapshot_from
     )
@@ -239,7 +237,6 @@ def update_sync(env_filepath: str, unsafe_ok: bool = False) -> None:
 @check_user
 def repair_sync(
     archive: bool,
-    catchup: bool,
     historic_state: bool,
     snapshot_from: str
 ) -> None:
@@ -249,7 +246,6 @@ def repair_sync(
     repair_sync_op(
         schain_name=schain_name,
         archive=archive,
-        catchup=catchup,
         historic_state=historic_state,
         snapshot_from=snapshot_from
     )

--- a/node_cli/operations/base.py
+++ b/node_cli/operations/base.py
@@ -187,7 +187,6 @@ def init_sync(
     env_filepath: str,
     env: dict,
     archive: bool,
-    catchup: bool,
     historic_state: bool,
     snapshot_from: Optional[str]
 ) -> bool:
@@ -208,7 +207,8 @@ def init_sync(
 
     node_options = NodeOptions()
     node_options.archive = archive
-    node_options.catchup = catchup
+    if archive:
+        node_options.catchup = True
     node_options.historic_state = historic_state
 
     ensure_filestorage_mapping()
@@ -352,7 +352,6 @@ def restore(env, backup_path, config_only=False):
 def repair_sync(
     schain_name: str,
     archive: bool,
-    catchup: bool,
     historic_state: bool,
     snapshot_from: Optional[str]
 ) -> None:
@@ -365,7 +364,8 @@ def repair_sync(
     logger.info('Updating node options')
     node_options = NodeOptions()
     node_options.archive = archive
-    node_options.catchup = catchup
+    if archive:
+        node_options.catchup = True
     node_options.historic_state = historic_state
 
     logger.info('Updating cli status')

--- a/tests/cli/sync_node_test.py
+++ b/tests/cli/sync_node_test.py
@@ -44,10 +44,16 @@ def test_init_sync(mocked_g_config):
         'node_cli.utils.decorators.is_node_inited', return_value=False
     ):
         result = run_command(_init_sync, ['./tests/test-env'])
+
+        node_options = NodeOptions()
+        assert not node_options.archive
+        assert not node_options.catchup
+        assert not node_options.historic_state
+
         assert result.exit_code == 0
 
 
-def test_init_sync_archive_catchup(mocked_g_config, clean_node_options):
+def test_init_sync_archive(mocked_g_config, clean_node_options):
     pathlib.Path(NODE_DATA_PATH).mkdir(parents=True, exist_ok=True)
     #     with mock.patch('subprocess.run', new=subprocess_run_mock), \
     with mock.patch('node_cli.core.node.is_base_containers_alive', return_value=True), mock.patch(
@@ -70,7 +76,7 @@ def test_init_sync_archive_catchup(mocked_g_config, clean_node_options):
         'node_cli.utils.decorators.is_node_inited', return_value=False
     ):
         result = run_command(
-            _init_sync, ['./tests/test-env', '--archive', '--catchup', '--historic-state']
+            _init_sync, ['./tests/test-env', '--archive', '--historic-state']
         )
         node_options = NodeOptions()
 

--- a/tests/core/core_node_test.py
+++ b/tests/core/core_node_test.py
@@ -191,4 +191,4 @@ def test_repair_sync(tmp_sync_datadir, mocked_g_config, resource_file):
     with mock.patch('node_cli.core.schains.rm_btrfs_subvolume'), \
          mock.patch('node_cli.utils.docker_utils.stop_container'), \
          mock.patch('node_cli.utils.docker_utils.start_container'):
-        repair_sync(archive=True, catchup=True, historic_state=True, snapshot_from='127.0.0.1')
+        repair_sync(archive=True, historic_state=True, snapshot_from='127.0.0.1')

--- a/text.yml
+++ b/text.yml
@@ -65,7 +65,6 @@ sync_node:
     help: Initialize sync SKALE node
     archive: Run sync node in an archive node (disable block rotation)
     historic_state: Enable historic state (works only in pair with --archive flag)
-    catchup: Add a flag to start sync node in catchup mode
 
 lvmpy:
   help: Lvmpy commands


### PR DESCRIPTION
**Changes**
- Remove `--catchup` option
- Set `catchup=True` when `--archive` is specified

**Performance**
- No performance related changes were made

**Testing**
- Tested on local network
- Covered by exiting unit tests