### PR TITLE
Ensure CLI output reflects active executable (`skale`/`mirage`)

### DIFF
--- a/node_cli/cli/mirage_boot.py
+++ b/node_cli/cli/mirage_boot.py
@@ -64,7 +64,7 @@ def init_boot(env_file):
 @click.option('--domain', '-d', prompt='Enter node domain name', type=str, help='Node domain name')
 @streamed_cmd
 def register_boot(name, ip, port, domain):
-    register(name=name, p2p_ip=ip, public_ip=ip, port=port, domain_name=domain)
+    register(name=name, p2p_ip=ip, public_ip=ip, port=port, domain_name=domain, is_mirage_boot=True)
 
 
 @boot.command('signature', help='Get mirage node signature for a validator ID (during Boot Phase).')

--- a/node_cli/cli/ssl.py
+++ b/node_cli/cli/ssl.py
@@ -25,6 +25,8 @@ from node_cli.utils.helper import error_exit
 from node_cli.utils.texts import safe_load_texts
 from node_cli.configs.ssl import DEFAULT_SSL_CHECK_PORT, SSL_CERT_FILEPATH, SSL_KEY_FILEPATH
 from node_cli.core.ssl import check_cert, upload_cert, cert_status
+from node_cli.cli.info import TYPE
+from node_cli.utils.node_type import NodeType
 
 
 TEXTS = safe_load_texts()
@@ -46,7 +48,10 @@ def status():
     status, payload = cert_status()
     if status == 'ok':
         if payload.get('is_empty'):
-            print(TEXTS['ssl']['no_cert'])
+            if TYPE == NodeType.MIRAGE:
+                print(TEXTS['ssl']['no_cert_mirage'])
+            else:
+                print(TEXTS['ssl']['no_cert'])
         else:
             table_data = [
                 ['Issued to', payload['issued_to']],
@@ -71,7 +76,10 @@ def status():
 def upload(key_path, cert_path, force):
     status, payload = upload_cert(cert_path, key_path, force)
     if status == 'ok':
-        print(TEXTS['ssl']['uploaded'])
+        if TYPE == NodeType.MIRAGE:
+            print(TEXTS['ssl']['uploaded_mirage'])
+        else:
+            print(TEXTS['ssl']['uploaded'])
     else:
         error_exit(payload)
 

--- a/node_cli/cli/wallet.py
+++ b/node_cli/cli/wallet.py
@@ -37,13 +37,13 @@ def wallet():
     pass
 
 
-@wallet.command('info', help='Get info about SKALE node wallet')
+@wallet.command('info', help='Get info about node wallet')
 @click.option('--format', '-f', type=click.Choice(['json', 'text']))
 def wallet_info(format):
     get_wallet_info(format)
 
 
-@wallet.command('send', help='Send ETH from SKALE node wallet to address')
+@wallet.command('send', help='Send ETH from node wallet to address')
 @click.argument('address')
 @click.argument('amount', type=float)
 @click.option(

--- a/node_cli/core/node.py
+++ b/node_cli/core/node.py
@@ -42,6 +42,7 @@ from node_cli.configs import (
     TM_INIT_TIMEOUT,
 )
 from node_cli.cli import __version__
+from node_cli.cli.info import TYPE
 from node_cli.configs.env import get_validated_env_config, SKALE_DIR_ENV_FILEPATH
 from node_cli.configs.cli_logger import LOG_DATA_PATH as CLI_LOG_DATA_PATH
 
@@ -120,9 +121,15 @@ def is_update_safe(node_type: NodeType) -> bool:
 
 @check_inited
 @check_user
-def register_node(name, p2p_ip, public_ip, port, domain_name):
+def register_node(name, p2p_ip, public_ip, port, domain_name, is_mirage_boot: bool = False) -> None:
     if not is_node_inited():
-        print(TEXTS['node']['not_inited'])
+        if TYPE == NodeType.MIRAGE:
+            if is_mirage_boot:
+                print(TEXTS['node']['not_inited_mirage_boot'])
+            else:
+                print(TEXTS['node']['not_inited_mirage'])
+        else:
+            print(TEXTS['node']['not_inited'])
         return
 
     # todo: add name, ips and port checks
@@ -135,7 +142,13 @@ def register_node(name, p2p_ip, public_ip, port, domain_name):
     }
     status, payload = post_request(blueprint=BLUEPRINT_NAME, method='register', json=json_data)
     if status == 'ok':
-        msg = TEXTS['node']['registered']
+        if TYPE == NodeType.MIRAGE:
+            if is_mirage_boot:
+                msg = TEXTS['node']['registered_mirage_boot']
+            else:
+                msg = TEXTS['node']['registered_mirage']
+        else:
+            msg = TEXTS['node']['registered']
         logger.info(msg)
         print(msg)
     else:
@@ -498,7 +511,10 @@ def run_checks(
     disk: Optional[str] = None,
 ) -> None:
     if not is_node_inited():
-        print(TEXTS['node']['not_inited'])
+        if TYPE == NodeType.MIRAGE:
+            print(TEXTS['node']['not_inited_mirage'])
+        else:
+            print(TEXTS['node']['not_inited'])
         return
 
     if disk is None:

--- a/node_cli/utils/decorators.py
+++ b/node_cli/utils/decorators.py
@@ -17,7 +17,6 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from encodings.punycode import T
 from functools import wraps
 
 from node_cli.core.host import is_node_inited

--- a/node_cli/utils/decorators.py
+++ b/node_cli/utils/decorators.py
@@ -17,6 +17,7 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from encodings.punycode import T
 from functools import wraps
 
 from node_cli.core.host import is_node_inited
@@ -24,6 +25,8 @@ from node_cli.utils.global_config import get_system_user
 from node_cli.utils.helper import error_exit, is_user_valid, get_g_conf_user
 from node_cli.utils.texts import safe_load_texts
 from node_cli.utils.exit_codes import CLIExitCodes
+from node_cli.cli.info import TYPE
+from node_cli.utils.node_type import NodeType
 
 
 TEXTS = safe_load_texts()
@@ -45,7 +48,12 @@ def check_inited(f):
     @wraps(f)
     def inner(*args, **kwargs):
         if not is_node_inited():
-            error_exit(TEXTS['node']['not_inited'], exit_code=CLIExitCodes.NODE_STATE_ERROR)
+            if TYPE == NodeType.MIRAGE:
+                error_exit(
+                    TEXTS['node']['not_inited_mirage'], exit_code=CLIExitCodes.NODE_STATE_ERROR
+                )
+            else:
+                error_exit(TEXTS['node']['not_inited'], exit_code=CLIExitCodes.NODE_STATE_ERROR)
         return f(*args, **kwargs)
 
     return inner

--- a/node_cli/utils/print_formatters.py
+++ b/node_cli/utils/print_formatters.py
@@ -26,10 +26,12 @@ from dateutil import parser
 
 import inspect
 
+from node_cli.cli.info import TYPE
 from node_cli.configs import LONG_LINE
 from node_cli.configs.cli_logger import DEBUG_LOG_FILEPATH
 from node_cli.utils.meta import CliMeta
 from node_cli.utils.texts import safe_load_texts
+from node_cli.utils.node_type import NodeType
 
 TEXTS = safe_load_texts()
 
@@ -226,7 +228,10 @@ def print_schain_info(info: dict, raw: bool = False) -> None:
 
 
 def print_node_cmd_error():
-    print(TEXTS['node']['cmd_failed'].format(DEBUG_LOG_FILEPATH))
+    if TYPE == NodeType.MIRAGE:
+        print(TEXTS['node']['cmd_failed_mirage'].format(DEBUG_LOG_FILEPATH))
+    else:
+        print(TEXTS['node']['cmd_failed'].format(DEBUG_LOG_FILEPATH))
 
 
 def print_node_info(node, node_status):

--- a/tests/cli/mirage_cli_test.py
+++ b/tests/cli/mirage_cli_test.py
@@ -122,7 +122,7 @@ def test_mirage_boot_register(mock_register_core):
 
     assert result.exit_code == 0, f'Output: {result.output}\nException: {result.exception}'
     mock_register_core.assert_called_once_with(
-        name=name, p2p_ip=ip, public_ip=ip, port=port, domain_name=domain
+        name=name, p2p_ip=ip, public_ip=ip, port=port, domain_name=domain, is_mirage_boot=True
     )
 
 

--- a/tests/cli/node_test.py
+++ b/tests/cli/node_test.py
@@ -189,7 +189,7 @@ def test_node_info_node_info_not_created():
     resp_mock = response_mock(requests.codes.ok, json_data={'payload': payload, 'status': 'ok'})
     result = run_command_mock('node_cli.utils.helper.requests.get', resp_mock, node_info)
     assert result.exit_code == 0
-    assert result.output == 'This SKALE node is not registered on SKALE Manager yet\n'
+    assert result.output == 'This node is not registered on SKALE Manager yet\n'
 
 
 def test_node_info_node_info_frozen():

--- a/text.yml
+++ b/text.yml
@@ -16,6 +16,12 @@ node:
   registered: |-
     Node registered in SKALE manager.
     For more info run < skale node info >
+  registered_mirage: |-
+    Node registered in SKALE manager.
+    For more info run < mirage node info >
+  registered_mirage_boot: |-
+    Node registered in SKALE manager.
+    For more info run < mirage boot info >
   status:
     ACTIVE: Active
     LEAVING: Leaving
@@ -27,24 +33,36 @@ node:
   not_inited: |-
     Node hasn't been inited before.
     You should run < skale node init >
+  not_inited_mirage: |-
+    Node hasn't been inited before.
+    You should run < mirage node init >
   already_inited: Node was already inited before.
   cmd_failed: |-
     Command failed. Please, check out < skale logs cli >
+    and logs from docker containers for more information
+  cmd_failed_mirage: |-
+    Command failed. Please, check out < mirage logs cli >
     and logs from docker containers for more information
   domain_name_changed: Domain name successfully changed
 wallet:
   successful_transfer: "Funds were successfully transferred"
 
 service:
-  node_not_registered: This SKALE node is not registered on SKALE Manager yet
+  node_not_registered: This node is not registered on SKALE Manager yet
 
 ssl:
   no_cert: |-
     No SSL certificates on the node. 
     Run < skale ssl upload > to add new certificates.
+  no_cert_mirage: |-
+    No SSL certificates on the node. 
+    Run < mirage ssl upload > to add new certificates.
   uploaded: |-
     Certificates are successfully uploaded.
     You can check status by running < skale ssl status >
+  uploaded_mirage: |-
+    Certificates are successfully uploaded.
+    You can check status by running < mirage ssl status >
   check_passed: |-
     Check passed
 


### PR DESCRIPTION
## Problem
User-facing messages in `node-cli` previously hardcoded "skale" as the executable, leading to incorrect command suggestions for `mirage` binary users.

## Solution
Updated CLI output logic to dynamically display the correct executable name (`skale` or `mirage`) based on the current `NodeType`. This involves:
- Contextual text selection in core CLI modules.
- Minor additions to `text.yml` for Mirage-specific message variants.

This change improves user experience by providing accurate command examples tailored to the active binary.