### PR TITLE
Fix check_ssl_connection() function

### DIFF
--- a/node_cli/core/ssl/check.py
+++ b/node_cli/core/ssl/check.py
@@ -201,8 +201,15 @@ def check_ssl_connection(host, port, silent=False):
     ]
     expose_output = not silent
     with detached_subprocess(ssl_check_cmd, expose_output=expose_output) as dp:
-        time.sleep(1)
-        code = dp.poll()
-        if code is not None:
+        for _ in range(10):
+            code = dp.poll()
+            if code is None:
+                logger.info('Healthcheck process still running...')
+                time.sleep(2)
+                continue
+            elif code == 0:
+                return
             logger.error('Healthcheck connection failed')
             raise SSLHealthcheckError('OpenSSL connection verification failed')
+        logger.error('Healthcheck timed-out')
+        raise SSLHealthcheckError('OpenSSL connection verification timed-out')

--- a/node_cli/core/ssl/check.py
+++ b/node_cli/core/ssl/check.py
@@ -20,6 +20,7 @@
 import time
 import socket
 import logging
+import subprocess
 from contextlib import contextmanager
 
 from node_cli.core.ssl.utils import detached_subprocess
@@ -201,15 +202,15 @@ def check_ssl_connection(host, port, silent=False):
     ]
     expose_output = not silent
     with detached_subprocess(ssl_check_cmd, expose_output=expose_output) as dp:
-        for _ in range(10):
-            code = dp.poll()
-            if code is None:
-                logger.info('Healthcheck process still running...')
-                time.sleep(2)
-                continue
-            elif code == 0:
-                return
-            logger.error('Healthcheck connection failed')
-            raise SSLHealthcheckError('OpenSSL connection verification failed')
-        logger.error('Healthcheck timed-out')
-        raise SSLHealthcheckError('OpenSSL connection verification timed-out')
+        timeout = 20
+        try:
+            dp.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            logger.error('Healthcheck timed-out after %s s', timeout)
+            raise SSLHealthcheckError('OpenSSL connection verification timed-out')
+
+        if dp.returncode == 0:  # success
+            return
+
+        logger.error('Healthcheck connection failed (code %s)', dp.returncode)
+        raise SSLHealthcheckError('OpenSSL connection verification failed')

--- a/node_cli/core/ssl/utils.py
+++ b/node_cli/core/ssl/utils.py
@@ -50,7 +50,7 @@ def detached_subprocess(cmd, expose_output=False):
     logger.debug(f'Starting detached subprocess: {cmd}')
     p = subprocess.Popen(
         cmd,
-        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL,
         encoding='utf-8'
     )
     try:


### PR DESCRIPTION
Function doesn't wait for `openssl s_client ...` to finish. It assumes that when the command is still running that is the successful condition. However the function should wait for exit code from the binary. We saw in production intermittent and very often `skale ssl upload` failures. This change should fix this problem and underlying race condition.

Related to:
- https://github.com/skalenetwork/node-cli/issues/868