### PR TITLE
Fix mirage boot api container

### DIFF
--- a/node_cli/utils/docker_utils.py
+++ b/node_cli/utils/docker_utils.py
@@ -65,17 +65,16 @@ BASE_SKALE_COMPOSE_SERVICES = {
     'bounty': 'skale_bounty',
 }
 
-CORE_MIRAGE_COMPOSE_SERVICES = {
+BASE_MIRAGE_COMPOSE_SERVICES = {
     **CORE_COMMON_COMPOSE_SERVICES,
+    'mirage-admin': 'mirage_admin',
     'mirage-api': 'mirage_api',
 }
-BASE_MIRAGE_COMPOSE_SERVICES = {
-    **CORE_MIRAGE_COMPOSE_SERVICES,
-    'mirage-admin': 'mirage_admin',
-}
+
 BASE_MIRAGE_BOOT_COMPOSE_SERVICES = {
-    **CORE_MIRAGE_COMPOSE_SERVICES,
+    **CORE_COMMON_COMPOSE_SERVICES,
     'mirage-boot': 'mirage_boot_admin',
+    'mirage-boot-api': 'mirage_boot_api',
 }
 
 BASE_SYNC_COMPOSE_SERVICES = {


### PR DESCRIPTION
This pull request refactors service definitions in `node_cli/utils/docker_utils.py` to simplify and consolidate the service composition logic. The most important change is the removal of `CORE_MIRAGE_COMPOSE_SERVICES` and its integration into other service groups.

### Refactoring service definitions:

* Removed `CORE_MIRAGE_COMPOSE_SERVICES` and directly integrated its services into `BASE_MIRAGE_COMPOSE_SERVICES` and `BASE_MIRAGE_BOOT_COMPOSE_SERVICES` to streamline service composition.
* Added new services `mirage-boot-api` to `BASE_MIRAGE_BOOT_COMPOSE_SERVICES` and ensured all service groups consistently inherit from `CORE_COMMON_COMPOSE_SERVICES`.