### PR TITLE
Fix fair node info and fair wallet info commands

### DIFF
--- a/node_cli/cli/mirage_node.py
+++ b/node_cli/cli/mirage_node.py
@@ -19,13 +19,18 @@
 
 import click
 
-from node_cli.core.node import backup, get_node_info, get_node_signature
+from node_cli.core.node import backup
 from node_cli.mirage.mirage_node import cleanup as mirage_cleanup
 from node_cli.mirage.mirage_node import init as init_mirage
-from node_cli.mirage.mirage_node import migrate_from_boot, request_repair, restore_mirage
+from node_cli.mirage.mirage_node import (
+    migrate_from_boot,
+    request_repair,
+    restore_mirage,
+    get_node_info,
+)
 from node_cli.mirage.mirage_node import register as register_mirage
 from node_cli.mirage.mirage_node import update as update_mirage
-from node_cli.utils.helper import IP_TYPE, URL_TYPE, abort_if_false, error_exit, streamed_cmd
+from node_cli.utils.helper import IP_TYPE, URL_TYPE, abort_if_false, streamed_cmd
 from node_cli.utils.texts import safe_load_texts
 
 TEXTS = safe_load_texts()
@@ -73,15 +78,6 @@ def register(ip: str) -> None:
 @streamed_cmd
 def update_node(env_filepath: str, pull_config_for_schain):
     update_mirage(env_filepath=env_filepath, pull_config_for_schain=pull_config_for_schain)
-
-
-@node.command('signature', help='Get mirage node signature for a validator ID.')
-@click.argument('validator_id')
-def signature_node(validator_id):
-    res = get_node_signature(validator_id)
-    if isinstance(res, dict) and 'error' in res:
-        error_exit(f'Error getting signature: {res.get("message", res)}')
-    print(f'Signature: {res}')
 
 
 @node.command('backup', help='Generate backup file for the Mirage node.')

--- a/node_cli/core/node.py
+++ b/node_cli/core/node.py
@@ -370,7 +370,7 @@ def create_backup_archive(backup_filepath):
     cli_log_path = CLI_LOG_DATA_PATH
     container_log_path = LOG_PATH
     pack_dir(SKALE_DIR, backup_filepath, exclude=(cli_log_path, container_log_path))
-    print(f'Backup archive succesfully created {backup_filepath}')
+    print(f'Backup archive successfully created {backup_filepath}')
 
 
 def set_maintenance_mode_on():

--- a/node_cli/core/wallet.py
+++ b/node_cli/core/wallet.py
@@ -20,8 +20,6 @@
 import json
 import logging
 
-from node_cli.cli.info import TYPE
-from node_cli.core.node import NodeType
 from node_cli.utils.exit_codes import CLIExitCodes
 from node_cli.utils.helper import error_exit, get_request, post_request
 from node_cli.utils.print_formatters import TEXTS, print_mirage_wallet_info, print_wallet_info
@@ -37,10 +35,13 @@ def get_wallet_info(_format):
         if _format == 'json':
             print(json.dumps(payload))
         else:
-            if TYPE == NodeType.MIRAGE:
-                print_mirage_wallet_info(payload)
-            else:
-                print_wallet_info(payload)
+            if type(payload) is str:
+                print(payload)
+            elif type(payload) is dict:
+                if payload.get('skale_balance'):
+                    print_wallet_info(payload)
+                else:
+                    print_mirage_wallet_info(payload)
     else:
         error_exit(payload, exit_code=CLIExitCodes.BAD_API_RESPONSE)
 

--- a/node_cli/mirage/mirage_node.py
+++ b/node_cli/mirage/mirage_node.py
@@ -20,6 +20,7 @@
 
 import logging
 import time
+from typing import cast
 
 from node_cli.configs import DEFAULT_SKALED_BASE_PORT, RESTORE_SLEEP_TIMEOUT, SKALE_DIR
 from node_cli.configs.user import SKALE_DIR_ENV_FILEPATH
@@ -36,15 +37,32 @@ from node_cli.operations import (
 )
 from node_cli.utils.decorators import check_inited, check_not_inited, check_user
 from node_cli.utils.exit_codes import CLIExitCodes
-from node_cli.utils.helper import error_exit, post_request
+from node_cli.utils.helper import error_exit, get_request, post_request
 from node_cli.utils.node_type import NodeType
-from node_cli.utils.print_formatters import print_node_cmd_error
+from node_cli.utils.print_formatters import print_node_cmd_error, print_node_info_mirage
 from node_cli.utils.texts import safe_load_texts
 
 logger = logging.getLogger(__name__)
 TEXTS = safe_load_texts()
 
-NODE_BLUEPRINT_NAME = 'mirage-node'
+BLUEPRINT_NAME = 'mirage-node'
+
+
+def get_node_info_plain() -> dict:
+    status, payload = get_request(blueprint=BLUEPRINT_NAME, method='info')
+    node_payload: dict = cast(dict, payload)
+    if status == 'ok':
+        return node_payload['node']
+    else:
+        error_exit(payload, exit_code=CLIExitCodes.BAD_API_RESPONSE)
+
+
+def get_node_info(format):
+    node_info = get_node_info_plain()
+    if format == 'json':
+        print(node_info)
+    else:
+        print_node_info_mirage(node_info)
 
 
 @check_not_inited
@@ -143,7 +161,7 @@ def register(ip: str) -> None:
         return
 
     json_data = {'ip': ip, 'port': DEFAULT_SKALED_BASE_PORT}
-    status, payload = post_request(blueprint=NODE_BLUEPRINT_NAME, method='register', json=json_data)
+    status, payload = post_request(blueprint=BLUEPRINT_NAME, method='register', json=json_data)
     if status == 'ok':
         msg = TEXTS['mirage']['node']['registered']
         logger.info(msg)

--- a/node_cli/utils/helper.py
+++ b/node_cli/utils/helper.py
@@ -210,14 +210,16 @@ def post_request(blueprint, method, json=None, files=None):
     return status, payload
 
 
-def get_request(blueprint: str, method: str, params: Optional[dict] = None) -> tuple[str, str]:
+def get_request(
+    blueprint: str, method: str, params: Optional[dict] = None
+) -> tuple[str, str | dict]:
     route = get_route(blueprint, method)
     url = construct_url(route)
     try:
         response = requests.get(url, params=params)
         data = response.json()
     except Exception as err:
-        logger.error('Request failed', exc_info=err)
+        logger.exception('Request failed', exc_info=err)
         data = DEFAULT_ERROR_DATA
 
     status = data['status']

--- a/node_cli/utils/print_formatters.py
+++ b/node_cli/utils/print_formatters.py
@@ -51,8 +51,8 @@ def print_mirage_wallet_info(wallet):
         inspect.cleandoc(f"""
         {LONG_LINE}
         Address: {wallet['address'].lower()}
-        MIRAGE balance: {wallet['mirage_balance']} ETH
-        MIRAGE balance WEI: {wallet['mirage_balance_wei']} WEI
+        Node balance: {wallet['mirage_balance']} MIRAGE
+        Node balance WEI: {wallet['mirage_balance_wei']} MIRAGE WEI
         {LONG_LINE}
         """)
     )
@@ -253,6 +253,20 @@ def print_node_info(node, node_status):
         Port: {node['port']}
         Domain name: {node['domain_name']}
         Status: {node_status}
+        {LONG_LINE}
+    """)
+    )
+
+
+def print_node_info_mirage(node):
+    print(
+        inspect.cleandoc(f"""
+        {LONG_LINE}
+        Node info
+        ID: {node['id']}
+        IP: {node['ip_str']}
+        Port: {node['port']}
+        Domain name: {node['domain_name']}
         {LONG_LINE}
     """)
     )

--- a/tests/cli/mirage_cli_test.py
+++ b/tests/cli/mirage_cli_test.py
@@ -12,7 +12,6 @@ from node_cli.cli.mirage_node import (
     backup_node,
     migrate_node,
     restore_node,
-    signature_node,
 )
 
 
@@ -52,34 +51,6 @@ def test_mirage_node_backup(mock_backup_core, tmp_path):
 
     assert result.exit_code == 0, f'Output: {result.output}\nException: {result.exception}'
     mock_backup_core.assert_called_once_with(backup_folder)
-
-
-@mock.patch('node_cli.cli.mirage_node.get_node_signature')
-def test_mirage_node_signature(mock_signature_core):
-    runner = CliRunner()
-    validator_id = '42'
-    signature_val = '0xabc123'
-    mock_signature_core.return_value = signature_val
-
-    result = runner.invoke(signature_node, [validator_id])
-
-    assert result.exit_code == 0, f'Output: {result.output}\nException: {result.exception}'
-    mock_signature_core.assert_called_once_with(validator_id)
-    assert f'Signature: {signature_val}' in result.output
-
-
-@mock.patch('node_cli.cli.mirage_node.get_node_signature')
-def test_mirage_node_signature_error(mock_signature_core):
-    runner = CliRunner()
-    validator_id = '43'
-    error_msg = 'Core layer error'
-    mock_signature_core.return_value = {'error': True, 'message': error_msg}
-
-    result = runner.invoke(signature_node, [validator_id])
-
-    assert result.exit_code != 0, f'Output: {result.output}\nException: {result.exception}'
-    mock_signature_core.assert_called_once_with(validator_id)
-    assert error_msg in result.output
 
 
 @mock.patch('node_cli.cli.mirage_boot.register')


### PR DESCRIPTION
This pull request introduces several updates and improvements to the Mirage Node CLI, including code cleanup, feature enhancements, and bug fixes. The most significant changes involve refactoring imports, adding new utility functions, improving error handling, and updating output formatting for better clarity.

### Code Cleanup and Refactoring:
* Consolidated and reordered imports in `node_cli/cli/mirage_node.py` to improve readability and maintainability. Unused imports like `get_node_signature` were removed, and others were grouped logically.
* Removed the `signature_node` command from `node_cli/cli/mirage_node.py`, as it is no longer needed.
* Renamed the `NODE_BLUEPRINT_NAME` constant to `BLUEPRINT_NAME` in `node_cli/mirage/mirage_node.py` for consistency and clarity.

### Feature Enhancements:
* Added `get_node_info_plain` and `get_node_info` functions in `node_cli/mirage/mirage_node.py` to fetch and display Mirage node information in plain or JSON format. [[1]](diffhunk://#diff-9b5d6f6bc94706f3b611fcc52e5db037b99121cfc5e9a6bdfa293f6ed338c3dcL39-R65) [[2]](diffhunk://#diff-9b5d6f6bc94706f3b611fcc52e5db037b99121cfc5e9a6bdfa293f6ed338c3dcR23)
* Introduced the `print_node_info_mirage` function in `node_cli/utils/print_formatters.py` to format and display Mirage node details in a user-friendly way.

### Error Handling Improvements:
* Updated the `get_request` function in `node_cli/utils/helper.py` to handle responses that may return either a string or a dictionary, improving flexibility and robustness. Also replaced `logger.error` with `logger.exception` for better error traceability.

### Output Formatting Updates:
* Fixed a typo in the success message for `create_backup_archive` in `node_cli/core/node.py` ("succesfully" → "successfully").
* Updated the `print_mirage_wallet_info` function in `node_cli/utils/print_formatters.py` to rename "MIRAGE balance" to "Node balance" for consistency and clarity.

### Other Changes:
* Adjusted logic in `get_wallet_info` in `node_cli/core/wallet.py` to handle payloads more dynamically, ensuring proper formatting based on the payload type.