### PR TITLE
Add FAIR repair

### DIFF
--- a/node_cli/cli/fair_node.py
+++ b/node_cli/cli/fair_node.py
@@ -21,13 +21,13 @@ import click
 
 from node_cli.core.node import backup
 from node_cli.fair.fair_node import cleanup as fair_cleanup
-from node_cli.fair.fair_node import init as init_fair
 from node_cli.fair.fair_node import (
-    migrate_from_boot,
-    request_repair,
-    restore_fair,
     get_node_info,
+    migrate_from_boot,
+    repair_chain,
+    restore_fair,
 )
+from node_cli.fair.fair_node import init as init_fair
 from node_cli.fair.fair_node import register as register_fair
 from node_cli.fair.fair_node import update as update_fair
 from node_cli.utils.helper import IP_TYPE, URL_TYPE, abort_if_false, streamed_cmd
@@ -119,7 +119,7 @@ def migrate_node(env_filepath: str) -> None:
 @click.option(
     '--snapshot-from',
     type=URL_TYPE,
-    default='',
+    default=None,
     hidden=True,
     help=TEXTS['fair']['node']['repair']['snapshot_from'],
 )
@@ -130,8 +130,9 @@ def migrate_node(env_filepath: str) -> None:
     expose_value=False,
     prompt=TEXTS['fair']['node']['repair']['warning'],
 )
-def repair(snapshot_from: str = '') -> None:
-    request_repair(snapshot_from=snapshot_from)
+@streamed_cmd
+def repair(snapshot_from: str | None = None) -> None:
+    repair_chain(snapshot_from=snapshot_from)
 
 
 @node.command('cleanup', help='Cleanup Fair node.')

--- a/node_cli/cli/fair_node.py
+++ b/node_cli/cli/fair_node.py
@@ -119,7 +119,7 @@ def migrate_node(env_filepath: str) -> None:
 @click.option(
     '--snapshot-from',
     type=URL_TYPE,
-    default=None,
+    default='any',
     hidden=True,
     help=TEXTS['fair']['node']['repair']['snapshot_from'],
 )
@@ -131,7 +131,7 @@ def migrate_node(env_filepath: str) -> None:
     prompt=TEXTS['fair']['node']['repair']['warning'],
 )
 @streamed_cmd
-def repair(snapshot_from: str | None = None) -> None:
+def repair(snapshot_from: str = 'any') -> None:
     repair_chain(snapshot_from=snapshot_from)
 
 

--- a/node_cli/core/node.py
+++ b/node_cli/core/node.py
@@ -28,6 +28,7 @@ from typing import Optional, Tuple
 
 import docker
 
+from node_cli.cli import __version__
 from node_cli.configs import (
     BACKUP_ARCHIVE_NAME,
     CONTAINER_CONFIG_PATH,
@@ -41,49 +42,46 @@ from node_cli.configs import (
     SKALE_STATE_DIR,
     TM_INIT_TIMEOUT,
 )
-from node_cli.cli import __version__
-from node_cli.configs.user import get_validated_user_config, SKALE_DIR_ENV_FILEPATH
 from node_cli.configs.cli_logger import LOG_DATA_PATH as CLI_LOG_DATA_PATH
-
-from node_cli.core.host import is_node_inited, save_env_params, get_flask_secret_key
+from node_cli.configs.user import SKALE_DIR_ENV_FILEPATH, get_validated_user_config
 from node_cli.core.checks import run_checks as run_host_checks
+from node_cli.core.host import get_flask_secret_key, is_node_inited, save_env_params
 from node_cli.core.resources import update_resource_allocation
+from node_cli.migrations.focal_to_jammy import migrate as migrate_2_6
 from node_cli.operations import (
+    cleanup_sync_op,
     configure_nftables,
-    update_op,
     init_op,
+    init_sync_op,
+    restore_op,
     turn_off_op,
     turn_on_op,
-    restore_op,
-    init_sync_op,
+    update_op,
     update_sync_op,
-    cleanup_sync_op,
 )
-from node_cli.utils.print_formatters import (
-    print_failed_requirements_checks,
-    print_node_cmd_error,
-    print_node_info,
+from node_cli.utils.decorators import check_inited, check_not_inited, check_user
+from node_cli.utils.docker_utils import (
+    BASE_FAIR_BOOT_COMPOSE_SERVICES,
+    BASE_FAIR_COMPOSE_SERVICES,
+    BASE_SKALE_COMPOSE_SERVICES,
+    BASE_SYNC_COMPOSE_SERVICES,
+    is_admin_running,
+    is_api_running,
 )
+from node_cli.utils.exit_codes import CLIExitCodes
 from node_cli.utils.helper import (
     error_exit,
     get_request,
     post_request,
 )
 from node_cli.utils.meta import CliMetaManager
-from node_cli.utils.texts import safe_load_texts
-from node_cli.utils.exit_codes import CLIExitCodes
-from node_cli.utils.decorators import check_not_inited, check_inited, check_user
-from node_cli.utils.docker_utils import (
-    is_admin_running,
-    is_api_running,
-    BASE_SKALE_COMPOSE_SERVICES,
-    BASE_SYNC_COMPOSE_SERVICES,
-    BASE_FAIR_COMPOSE_SERVICES,
-    BASE_FAIR_BOOT_COMPOSE_SERVICES,
-)
 from node_cli.utils.node_type import NodeType
-from node_cli.migrations.focal_to_jammy import migrate as migrate_2_6
-
+from node_cli.utils.print_formatters import (
+    print_failed_requirements_checks,
+    print_node_cmd_error,
+    print_node_info,
+)
+from node_cli.utils.texts import safe_load_texts
 
 logger = logging.getLogger(__name__)
 TEXTS = safe_load_texts()

--- a/node_cli/fair/fair_node.py
+++ b/node_cli/fair/fair_node.py
@@ -27,11 +27,11 @@ from node_cli.configs.user import SKALE_DIR_ENV_FILEPATH
 from node_cli.core.docker_config import cleanup_docker_configuration
 from node_cli.core.host import is_node_inited, save_env_params
 from node_cli.core.node import compose_node_env, is_base_containers_alive
-from node_cli.fair.record.chain_record import get_fair_chain_record
 from node_cli.operations import (
     FairUpdateType,
     cleanup_fair_op,
     init_fair_op,
+    repair_fair_op,
     restore_fair_op,
     update_fair_op,
 )
@@ -121,14 +121,6 @@ def update(env_filepath: str, pull_config_for_schain: str | None = None) -> None
         logger.info('Fair update completed successfully')
 
 
-def request_repair(snapshot_from: str = '') -> None:
-    env = compose_node_env(SKALE_DIR_ENV_FILEPATH, save=False, node_type=NodeType.FAIR)
-    record = get_fair_chain_record(env)
-    record.set_repair_ts(int(time.time()))
-    record.set_snapshot_from(snapshot_from)
-    print(TEXTS['fair']['node']['repair']['repair_requested'])
-
-
 @check_user
 def cleanup() -> None:
     env = compose_node_env(SKALE_DIR_ENV_FILEPATH, save=False, node_type=NodeType.FAIR)
@@ -169,3 +161,8 @@ def register(ip: str) -> None:
         error_msg = payload
         logger.error(f'Registration error {error_msg}')
         error_exit(error_msg, exit_code=CLIExitCodes.BAD_API_RESPONSE)
+
+
+def repair_chain(snapshot_from: str | None = None) -> None:
+    env = compose_node_env(SKALE_DIR_ENV_FILEPATH, save=False, node_type=NodeType.FAIR)
+    repair_fair_op(env=env, snapshot_from=snapshot_from)

--- a/node_cli/fair/fair_node.py
+++ b/node_cli/fair/fair_node.py
@@ -163,6 +163,6 @@ def register(ip: str) -> None:
         error_exit(error_msg, exit_code=CLIExitCodes.BAD_API_RESPONSE)
 
 
-def repair_chain(snapshot_from: str | None = None) -> None:
+def repair_chain(snapshot_from: str = 'any') -> None:
     env = compose_node_env(SKALE_DIR_ENV_FILEPATH, save=False, node_type=NodeType.FAIR)
     repair_fair_op(env=env, snapshot_from=snapshot_from)

--- a/node_cli/operations/__init__.py
+++ b/node_cli/operations/__init__.py
@@ -32,8 +32,9 @@ from node_cli.operations.base import (  # noqa
 )
 from node_cli.operations.fair import (  # noqa
     init as init_fair_op,
-    update_fair as update_fair_op,
+    update as update_fair_op,
     FairUpdateType,
-    restore_fair as restore_fair_op,
+    restore as restore_fair_op,
+    repair as repair_fair_op,
     cleanup as cleanup_fair_op,
 )

--- a/node_cli/operations/fair.py
+++ b/node_cli/operations/fair.py
@@ -37,7 +37,7 @@ from node_cli.core.host import ensure_btrfs_kernel_module_autoloaded, link_env_f
 from node_cli.core.nftables import configure_nftables
 from node_cli.core.nginx import generate_nginx_config
 from node_cli.core.schains import cleanup_no_lvm_datadir
-from node_cli.fair.record.chain_record import migrate_chain_record
+from node_cli.fair.record.chain_record import get_fair_chain_record, migrate_chain_record
 from node_cli.migrations.fair.from_boot import migrate_nftables_from_boot
 from node_cli.operations.base import checked_host, turn_off
 from node_cli.operations.common import configure_filebeat, configure_flask, unpack_backup_archive
@@ -53,12 +53,15 @@ from node_cli.utils.docker_utils import (
     compose_rm,
     compose_up,
     docker_cleanup,
+    is_admin_running,
     remove_dynamic_containers,
+    start_container_by_name,
+    stop_container_by_name,
     wait_for_container,
 )
 from node_cli.utils.helper import cleanup_dir_content, rm_dir, str_to_bool
 from node_cli.utils.meta import FairCliMetaManager
-from node_cli.utils.print_formatters import print_failed_requirements_checks
+from node_cli.utils.print_formatters import TEXTS, print_failed_requirements_checks
 
 logger = logging.getLogger(__name__)
 
@@ -145,7 +148,7 @@ def update_fair_boot(env_filepath: str, env: dict) -> bool:
 
 
 @checked_host
-def update_fair(env_filepath: str, env: dict, update_type: FairUpdateType) -> bool:
+def update(env_filepath: str, env: dict, update_type: FairUpdateType) -> bool:
     compose_rm(node_type=NodeType.FAIR, env=env)
     if update_type not in (FairUpdateType.INFRA_ONLY, FairUpdateType.FROM_BOOT):
         remove_dynamic_containers()
@@ -193,7 +196,7 @@ def update_fair(env_filepath: str, env: dict, update_type: FairUpdateType) -> bo
     return True
 
 
-def restore_fair(env, backup_path, config_only=False):
+def restore(env, backup_path, config_only=False):
     unpack_backup_archive(backup_path)
     failed_checks = run_host_checks(
         env['DISK_MOUNTPOINT'],
@@ -240,10 +243,36 @@ def restore_fair(env, backup_path, config_only=False):
     return True
 
 
-def cleanup(env) -> None:
+def cleanup(env: dict) -> None:
     turn_off(env, node_type=NodeType.FAIR)
     cleanup_no_lvm_datadir()
     rm_dir(GLOBAL_SKALE_DIR)
     rm_dir(SKALE_DIR)
     cleanup_dir_content(NFTABLES_CHAIN_FOLDER_PATH)
     cleanup_docker_configuration()
+
+
+def request_repair(env: dict, snapshot_from: str | None = None) -> None:
+    record = get_fair_chain_record(env)
+    record.set_repair_ts(int(time.time()))
+    if not snapshot_from:
+        snapshot_from = ''
+    record.set_snapshot_from(snapshot_from)
+    print(TEXTS['fair']['node']['repair']['repair_requested'])
+
+
+def repair(env: dict, snapshot_from: str | None = None) -> None:
+    logger.info('Starting fair node repair')
+    container_name = 'fair_admin'
+    if is_admin_running(node_type=NodeType.FAIR):
+        logger.info('Stopping admin container')
+        stop_container_by_name(container_name=container_name)
+    logger.info('Removing chain container')
+    remove_dynamic_containers()
+    logger.info('Cleaning up datadir')
+    cleanup_no_lvm_datadir()
+    logger.info('Requesting fair node repair')
+    request_repair(env=env, snapshot_from=snapshot_from)
+    logger.info('Starting admin')
+    start_container_by_name(container_name=container_name)
+    logger.info('Fair node repair completed successfully')

--- a/node_cli/operations/fair.py
+++ b/node_cli/operations/fair.py
@@ -252,16 +252,16 @@ def cleanup(env: dict) -> None:
     cleanup_docker_configuration()
 
 
-def request_repair(env: dict, snapshot_from: str | None = None) -> None:
+def request_repair(env: dict, snapshot_from: str = 'any') -> None:
     record = get_fair_chain_record(env)
-    record.set_repair_ts(int(time.time()))
+    # record.set_repair_ts(int(time.time()))
     if not snapshot_from:
-        snapshot_from = ''
+        snapshot_from = 'any'
     record.set_snapshot_from(snapshot_from)
     print(TEXTS['fair']['node']['repair']['repair_requested'])
 
 
-def repair(env: dict, snapshot_from: str | None = None) -> None:
+def repair(env: dict, snapshot_from: str = 'any') -> None:
     logger.info('Starting fair node repair')
     container_name = 'fair_admin'
     if is_admin_running(node_type=NodeType.FAIR):

--- a/node_cli/operations/fair.py
+++ b/node_cli/operations/fair.py
@@ -252,9 +252,8 @@ def cleanup(env: dict) -> None:
     cleanup_docker_configuration()
 
 
-def request_repair(env: dict, snapshot_from: str = 'any') -> None:
+def trigger_skaled_snapshot_mode(env: dict, snapshot_from: str = 'any') -> None:
     record = get_fair_chain_record(env)
-    # record.set_repair_ts(int(time.time()))
     if not snapshot_from:
         snapshot_from = 'any'
     record.set_snapshot_from(snapshot_from)
@@ -272,7 +271,7 @@ def repair(env: dict, snapshot_from: str = 'any') -> None:
     logger.info('Cleaning up datadir')
     cleanup_no_lvm_datadir()
     logger.info('Requesting fair node repair')
-    request_repair(env=env, snapshot_from=snapshot_from)
+    trigger_skaled_snapshot_mode(env=env, snapshot_from=snapshot_from)
     logger.info('Starting admin')
     start_container_by_name(container_name=container_name)
     logger.info('Fair node repair completed successfully')

--- a/node_cli/utils/docker_utils.py
+++ b/node_cli/utils/docker_utils.py
@@ -160,7 +160,7 @@ def safe_rm(container: Container, timeout=DOCKER_DEFAULT_STOP_TIMEOUT, **kwargs)
     logger.info(f'Container removed: {container_name}')
 
 
-def stop_container(
+def stop_container_by_name(
     container_name: str,
     timeout: int = DOCKER_DEFAULT_STOP_TIMEOUT,
     dclient: Optional[DockerClient] = None,
@@ -171,7 +171,7 @@ def stop_container(
     container.stop(timeout=timeout)
 
 
-def rm_container(
+def remove_container_by_name(
     container_name: str,
     timeout: int = DOCKER_DEFAULT_STOP_TIMEOUT,
     dclient: Optional[DockerClient] = None,
@@ -180,19 +180,21 @@ def rm_container(
     container_names = [container.name for container in get_containers()]
     if container_name in container_names:
         container = dc.containers.get(container_name)
-        safe_rm(container)
+        safe_rm(container, timeout=timeout)
 
 
-def start_container(container_name: str, dclient: Optional[DockerClient] = None) -> None:
+def start_container_by_name(container_name: str, dclient: Optional[DockerClient] = None) -> None:
     dc = dclient or docker_client()
     container = dc.containers.get(container_name)
     logger.info('Starting container %s', container_name)
     container.start()
 
 
-def remove_schain_container(schain_name: str, dclient: Optional[DockerClient] = None) -> None:
+def remove_schain_container_by_name(
+    schain_name: str, dclient: Optional[DockerClient] = None
+) -> None:
     container_name = f'skale_schain_{schain_name}'
-    rm_container(container_name, timeout=SCHAIN_REMOVE_TIMEOUT, dclient=dclient)
+    remove_container_by_name(container_name, timeout=SCHAIN_REMOVE_TIMEOUT, dclient=dclient)
 
 
 def backup_container_logs(
@@ -401,14 +403,12 @@ def is_api_running(node_type: NodeType, dclient: Optional[DockerClient] = None) 
 
 
 def is_admin_running(node_type: NodeType, client: Optional[DockerClient] = None) -> bool:
+    container_name = 'skale_admin'
     if node_type == NodeType.FAIR:
-        result = is_container_running(name='fair_admin', dclient=client)
+        container_name = 'fair_admin'
     elif node_type == NodeType.SYNC:
-        result = is_container_running(name='skale_sync_admin', dclient=client)
-    else:
-        result = is_container_running(name='skale_admin', dclient=client)
-
-    return result
+        container_name = 'skale_sync_admin'
+    return is_container_running(name=container_name, dclient=client)
 
 
 def system_prune():

--- a/tests/fair/fair_node_test.py
+++ b/tests/fair/fair_node_test.py
@@ -1,16 +1,14 @@
 from unittest import mock
 
-import freezegun
 import pytest
 
 from node_cli.configs import SKALE_DIR
 from node_cli.configs.user import SKALE_DIR_ENV_FILEPATH
 from node_cli.fair.fair_boot import init as init_boot
 from node_cli.fair.fair_boot import update
-from node_cli.fair.fair_node import cleanup, migrate_from_boot, request_repair, restore_fair
+from node_cli.fair.fair_node import cleanup, migrate_from_boot, restore_fair
 from node_cli.operations.fair import FairUpdateType
 from node_cli.utils.node_type import NodeType
-from tests.helper import CURRENT_DATETIME, CURRENT_TIMESTAMP
 
 
 @mock.patch('node_cli.fair.fair_node.time.sleep')
@@ -131,18 +129,6 @@ def test_migrate_from_boot(
     )
 
 
-@freezegun.freeze_time(CURRENT_DATETIME)
-@mock.patch('node_cli.fair.fair_node.compose_node_env', return_value={'ENV_TYPE': 'devnet'})
-@mock.patch('node_cli.fair.record.chain_record.get_fair_chain_name', return_value='test')
-def test_fair_repair(compose_node_env_mock, get_static_params_mock, redis_client, inited_node):
-    request_repair()
-    assert redis_client.get('test_repair_ts') == f'{CURRENT_TIMESTAMP}'.encode('utf-8')
-    assert redis_client.get('test_snapshot_from') == b''
-    request_repair(snapshot_from='127.0.0.1')
-    assert redis_client.get('test_repair_ts') == f'{CURRENT_TIMESTAMP}'.encode('utf-8')
-    assert redis_client.get('test_snapshot_from') == b'127.0.0.1'
-
-
 @mock.patch('node_cli.utils.decorators.is_user_valid', return_value=True)
 @mock.patch('node_cli.fair.fair_node.cleanup_docker_configuration')
 @mock.patch('node_cli.fair.fair_node.cleanup_fair_op')
@@ -203,9 +189,7 @@ def test_cleanup_calls_operations_in_correct_order(
 
 @mock.patch('node_cli.utils.decorators.is_user_valid', return_value=True)
 @mock.patch('node_cli.fair.fair_node.cleanup_docker_configuration')
-@mock.patch(
-    'node_cli.fair.fair_node.cleanup_fair_op', side_effect=Exception('Cleanup failed')
-)
+@mock.patch('node_cli.fair.fair_node.cleanup_fair_op', side_effect=Exception('Cleanup failed'))
 @mock.patch('node_cli.fair.fair_node.compose_node_env')
 def test_cleanup_continues_after_fair_op_error(
     mock_compose_env,


### PR DESCRIPTION
This pull request introduces several changes to improve the functionality and maintainability of the `node_cli` codebase. The changes include refactoring methods, renaming functions for clarity, adding new utility functions, and updating the logic for handling Fair node operations. Below is a summary of the most important changes, grouped by theme.

### Refactoring and Code Simplification:
* Reorganized imports across multiple files to improve readability and maintain alphabetical order. (`node_cli/cli/fair_node.py`, `node_cli/core/node.py`, `node_cli/operations/fair.py`)
* Renamed several functions for clarity, such as `stop_container` to `stop_container_by_name` and `rm_container` to `remove_container_by_name`. (`node_cli/utils/docker_utils.py`, [[1]](diffhunk://#diff-1cdcc39bb87001d426b4cff8b2724acd075ffb6ba9ed4e9b8b07d383ef9ed535L163-R163) [[2]](diffhunk://#diff-1cdcc39bb87001d426b4cff8b2724acd075ffb6ba9ed4e9b8b07d383ef9ed535L183-R197)

### Fair Node Operations:
* Replaced the `request_repair` function with a new `repair_chain` function, which integrates the `repair_fair_op` operation for better modularity. (`node_cli/fair/fair_node.py`, [[1]](diffhunk://#diff-2f82f30c374ab8a51e09163549a12b05544deb7793f40e09c028aa2457d91364L133-R135) [[2]](diffhunk://#diff-59b2555c4af1bb922282c47c13a5be19fecf4f52cb5b4df19f8d461cd89768bfR164-R168)
* Updated the `repair` command to use `repair_chain` and added the `@streamed_cmd` decorator for improved command output handling. (`node_cli/cli/fair_node.py`, [node_cli/cli/fair_node.pyL133-R135](diffhunk://#diff-2f82f30c374ab8a51e09163549a12b05544deb7793f40e09c028aa2457d91364L133-R135))

### Cleanup and Volume Management:
* Refactored the `cleanup_datadir_for_single_chain_node` function into `cleanup_datadir_content` and `cleanup_no_lvm_datadir` for better separation of concerns and reusability. (`node_cli/core/schains.py`, [node_cli/core/schains.pyL256-R304](diffhunk://#diff-0e0b7382b96158cf25c4f92aebbe86caa7643e49389f357c64288832ea04b9a7L256-R304))
* Added a new utility function `cleanup_dir_content` to remove the contents of a directory while preserving the directory itself. (`node_cli/utils/helper.py`, [node_cli/utils/helper.pyR327-R337](diffhunk://#diff-0ed14c647052f41baec2f3ba4e9b5ed4772788948531b437fca8dc6afb19f1b4R327-R337))

### Utility Enhancements:
* Introduced a new function `is_btrfs_subvolume` to check if a given path is a Btrfs subvolume, improving the handling of Btrfs-specific operations. (`node_cli/utils/helper.py`, [node_cli/utils/helper.pyR416-R424](diffhunk://#diff-0ed14c647052f41baec2f3ba4e9b5ed4772788948531b437fca8dc6afb19f1b4R416-R424))
* Added logic to ensure the correct container name is used when checking if an admin container is running for different node types. (`node_cli/utils/docker_utils.py`, [node_cli/utils/docker_utils.pyR406-R411](diffhunk://#diff-1cdcc39bb87001d426b4cff8b2724acd075ffb6ba9ed4e9b8b07d383ef9ed535R406-R411))

### Functionality Updates:
* Updated the `restore` and `update` operations for Fair nodes to align with the new function naming conventions and improved logic. (`node_cli/operations/fair.py`, [[1]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cL147-R151) [[2]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cL195-R199)
* Modified the default value for the `--snapshot-from` option in the `repair` command from an empty string (`''`) to `None` for better type consistency. (`node_cli/cli/fair_node.py`, [node_cli/cli/fair_node.pyL122-R122](diffhunk://#diff-2f82f30c374ab8a51e09163549a12b05544deb7793f40e09c028aa2457d91364L122-R122))