### PR TITLE
Add change IP command

### DIFF
--- a/node_cli/cli/fair_node.py
+++ b/node_cli/cli/fair_node.py
@@ -150,10 +150,11 @@ def cleanup_node():
 
 
 @node.command('change-ip', help=TEXTS['fair']['node']['change-ip']['help'])
-@click.option('--ip',
-              required=True,
-              type=IP_TYPE,
-              help=TEXTS['fair']['node']['change-ip']['ip']
+@click.option(
+    '--ip',
+    required=True,
+    type=IP_TYPE,
+    help=TEXTS['fair']['node']['change-ip']['ip']
 )
 def change_ip(ip: str) -> None:
     change_ip_fair(ip=ip)

--- a/node_cli/cli/fair_node.py
+++ b/node_cli/cli/fair_node.py
@@ -30,6 +30,7 @@ from node_cli.fair.fair_node import (
 from node_cli.fair.fair_node import init as init_fair
 from node_cli.fair.fair_node import register as register_fair
 from node_cli.fair.fair_node import update as update_fair
+from node_cli.fair.fair_node import change_ip as change_ip_fair
 from node_cli.utils.helper import IP_TYPE, URL_TYPE, abort_if_false, streamed_cmd
 from node_cli.utils.texts import safe_load_texts
 
@@ -146,3 +147,13 @@ def repair(snapshot_from: str = 'any') -> None:
 @streamed_cmd
 def cleanup_node():
     fair_cleanup()
+
+
+@node.command('change-ip', help=TEXTS['fair']['node']['change-ip']['help'])
+@click.option('--ip',
+              required=True,
+              type=IP_TYPE,
+              help=TEXTS['fair']['node']['change-ip']['ip']
+)
+def change_ip(ip: str) -> None:
+    change_ip_fair(ip=ip)

--- a/node_cli/cli/fair_node.py
+++ b/node_cli/cli/fair_node.py
@@ -150,11 +150,9 @@ def cleanup_node():
 
 
 @node.command('change-ip', help=TEXTS['fair']['node']['change-ip']['help'])
-@click.option(
-    '--ip',
-    required=True,
-    type=IP_TYPE,
-    help=TEXTS['fair']['node']['change-ip']['ip']
+@click.argument(
+    'ip',
+    type=IP_TYPE
 )
 def change_ip(ip: str) -> None:
     change_ip_fair(ip=ip)

--- a/node_cli/configs/routes.py
+++ b/node_cli/configs/routes.py
@@ -40,7 +40,7 @@ ROUTES = {
         'schains': ['config', 'list', 'dkg-statuses', 'firewall-rules', 'repair', 'get'],
         'ssl': ['status', 'upload'],
         'wallet': ['info', 'send-eth'],
-        'fair-node': ['info', 'register'],
+        'fair-node': ['info', 'register', 'change-ip'],
     }
 }
 

--- a/node_cli/fair/fair_node.py
+++ b/node_cli/fair/fair_node.py
@@ -166,3 +166,22 @@ def register(ip: str) -> None:
 def repair_chain(snapshot_from: str = 'any') -> None:
     env = compose_node_env(SKALE_DIR_ENV_FILEPATH, save=False, node_type=NodeType.FAIR)
     repair_fair_op(env=env, snapshot_from=snapshot_from)
+
+
+@check_inited
+@check_user
+def change_ip(ip: str) -> None:
+    if not is_node_inited():
+        print(TEXTS['fair']['node']['not_inited'])
+        return
+
+    json_data = {'ip': ip, 'port': DEFAULT_SKALED_BASE_PORT}
+    status, payload = post_request(blueprint=BLUEPRINT_NAME, method='change-ip', json=json_data)
+    if status == 'ok':
+        msg = TEXTS['fair']['node']['ip_changed']
+        logger.info(msg)
+        print(msg)
+    else:
+        error_msg = payload
+        logger.error(f'Change IP error {error_msg}')
+        error_exit(error_msg, exit_code=CLIExitCodes.BAD_API_RESPONSE)

--- a/tests/routes_test.py
+++ b/tests/routes_test.py
@@ -33,6 +33,7 @@ ALL_V1_ROUTES = [
     '/api/v1/wallet/send-eth',
     '/api/v1/fair-node/info',
     '/api/v1/fair-node/register',
+    '/api/v1/fair-node/change-ip',
 ]
 
 

--- a/text.yml
+++ b/text.yml
@@ -94,4 +94,3 @@ fair:
     ip_changed: Node IP changed in Fair manager
     change-ip:
       help: Change the node IP in Fair manager
-      ip: New IP address of the node in Fair manager

--- a/text.yml
+++ b/text.yml
@@ -91,3 +91,7 @@ fair:
       help: Register node in fair manager
       name: Name of the node in fair manager
       ip: IP address of the node in fair manager
+    ip_changed: Node IP changed in fair manager
+    change-ip:
+      help: Change the node IP in fair manager
+      ip: New IP address of the node in fair manager

--- a/text.yml
+++ b/text.yml
@@ -80,18 +80,18 @@ lvmpy:
 fair:
   node:
     repair:
-      help: Repair fair chain node
-      warning: Are you sure you want to repair fair chain node? In rare cases may cause data loss and require additional maintenance
+      help: Repair Fair chain node
+      warning: Are you sure you want to repair Fair chain node? In rare cases may cause data loss and require additional maintenance
       snapshot_from: IP of the node to take snapshot from
       repair_requested: Repair mode is requested
     not_inited: Node should be initialized to proceed with operation
 
-    registered: Node is registered in fair manager.
+    registered: Node is registered in Fair manager.
     register:
-      help: Register node in fair manager
-      name: Name of the node in fair manager
-      ip: IP address of the node in fair manager
-    ip_changed: Node IP changed in fair manager
+      help: Register node in Fair manager
+      name: Name of the node in Fair manager
+      ip: IP address of the node in Fair manager
+    ip_changed: Node IP changed in Fair manager
     change-ip:
-      help: Change the node IP in fair manager
-      ip: New IP address of the node in fair manager
+      help: Change the node IP in Fair manager
+      ip: New IP address of the node in Fair manager


### PR DESCRIPTION
This pull request introduces a new feature to support changing the IP address of a Fair chain node via the CLI. It also includes updates to the related route configurations and text resources. Below are the most important changes grouped by theme:

### New Feature: Change Node IP
* Added a `change_ip` function in `node_cli/fair/fair_node.py` to handle the logic for changing the node's IP address. This includes validation, making an API request, and handling success or error responses.
* Introduced a new CLI command `change-ip` in `node_cli/cli/fair_node.py` that uses the `change_ip` function to allow users to update the IP address of a Fair chain node.

### Route Configuration Updates
* Updated the `fair-node` routes in `node_cli/configs/routes.py` to include the new `change-ip` command.

### Text Resource Updates
* Added text resources for the `change-ip` command, including help text and success messages, in `text.yml`. Also made capitalization adjustments for consistency in existing Fair chain node-related texts.

### Import Updates
* Added an import for the `change_ip` function in `node_cli/cli/fair_node.py` to enable its use in the CLI command.