### PR TITLE
Add force config update

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ SKALE Node CLI, part of the SKALE suite of validator tools, is the command line 
    1. [Top level commands (Fair)](#top-level-commands-fair)
    2. [Fair Boot commands](#fair-boot-commands)
    3. [Fair Node commands](#fair-node-commands)
+   4. [Fair Wallet commands](#fair-wallet-commands)
+   5. [Fair Logs commands](#fair-logs-commands)
+   6. [Fair SSL commands](#fair-ssl-commands)
 5. [Exit codes](#exit-codes)
 6. [Development](#development)
 
@@ -679,17 +682,29 @@ Options:
 
 Commands for a Fair node in the Boot phase.
 
+#### Fair Boot Info
+
+Get information about the Fair node during boot phase.
+
+```shell
+fair boot info [--format FORMAT]
+```
+
+Options:
+
+* `--format`/`-f` - Output format (`json` or `text`).
+
 #### Fair Boot Initialization
 
 Initialize the Fair node boot phase.
 
 ```shell
-fair boot init [ENV_FILE]
+fair boot init <ENV_FILE>
 ```
 
 Arguments:
 
-* `ENV_FILE` - path to .env file (required).
+* `ENV_FILE` - Path to the environment file containing configuration.
 
 Required environment variables in `ENV_FILE`:
 
@@ -714,19 +729,16 @@ Register the Fair node with Fair Manager *during* the boot phase.
 fair boot register --name <NODE_NAME> --ip <PUBLIC_IP> --domain <DOMAIN_NAME> [--port <BASE_PORT>]
 ```
 
-Required arguments:
+Options:
 
-* `--name`/`-n` - Fair node name.
-* `--ip` - Public IP for RPC connections and consensus.
-* `--domain`/`-d` - Fair node domain name (e.g., `fair1.example.com`).
-
-Optional arguments:
-
-* `--port`/`-p` - Base port for node sChains (default: `10000`).
+* `--name`/`-n` - Fair node name (required).
+* `--ip` - Public IP for RPC connections & consensus (required).
+* `--domain`/`-d` - Fair node domain name (e.g., `fair1.example.com`, required).
+* `--port`/`-p` - Base port for node sChains (default: from configuration).
 
 #### Fair Boot Signature
 
-Get the node signature for a validator ID *during* the boot phase.
+Get the node signature for a validator ID during boot phase.
 
 ```shell
 fair boot signature <VALIDATOR_ID>
@@ -736,21 +748,37 @@ Arguments:
 
 * `VALIDATOR_ID` - The ID of the validator requesting the signature.
 
-#### Fair Boot Migrate
+#### Fair Boot Update
 
-Migrate the Fair node from the boot phase to the main phase (regular operation).
+Update the Fair node software during boot phase.
 
 ```shell
-fair boot migrate [ENV_FILEPATH] [--yes]
+fair boot update <ENV_FILE> [--yes] [--pull-config SCHAIN]
 ```
 
 Arguments:
 
-* `ENV_FILEPATH` - Path to the .env file.
+* `ENV_FILE` - Path to the environment file for node configuration.
+
+Required environment variables in `ENV_FILE`:
+
+* `SGX_SERVER_URL` - SGX server URL.
+* `DISK_MOUNTPOINT` - Mount point for storing data (BTRFS recommended).
+* `NODE_VERSION` - Stream of `skale-node` configs.
+* `ENDPOINT` - RPC endpoint of the network where Fair Manager is deployed.
+* `MANAGER_CONTRACTS` - SKALE Manager alias or address.
+* `IMA_CONTRACTS` - IMA alias or address (*Note: Required by boot service, may not be used by Fair itself*).
+* `FILEBEAT_HOST` - URL/IP:Port of the Filebeat log server.
+* `ENV_TYPE` - Environment type (e.g., 'mainnet', 'devnet').
+
+Optional variables:
+
+* `MONITORING_CONTAINERS` - Enable monitoring containers (`cadvisor`, `node-exporter`).
 
 Options:
 
-* `--yes` - Migrate without confirmation.
+* `--yes` - Update without confirmation prompt.
+* `--pull-config` - Pull configuration for specific sChain (hidden option).
 
 ### Fair Node commands
 
@@ -758,47 +786,129 @@ Options:
 
 Commands for managing a Fair node during its regular operation (main phase).
 
-#### Fair Node Initialization (Placeholder)
+#### Fair Node Info
+
+Get information about the Fair node.
+
+```shell
+fair node info [--format FORMAT]
+```
+
+Options:
+
+* `--format`/`-f` - Output format (`json` or `text`).
+
+#### Fair Node Initialization
 
 Initialize the regular operation phase of the Fair node.
 
 ```shell
-fair node init
-```
-
-> **Note:** This command is currently a placeholder and not implemented.
-
-#### Fair Node Registration (Placeholder)
-
-Register the node during regular operation.
-
-```shell
-fair node register
-```
-
-> **Note:** This command is currently a placeholder and not implemented.
-
-#### Fair Node Update (Placeholder)
-
-Update the Fair node during regular operation.
-
-```shell
-fair node update [ENV_FILEPATH] [--yes] [--unsafe]
-```
-
-> **Note:** This command is currently a placeholder and not implemented.
-
-#### Fair Node Signature
-
-Get the node signature for a validator ID during regular operation.
-
-```shell
-fair node signature <VALIDATOR_ID>
+fair node init <ENV_FILEPATH>
 ```
 
 Arguments:
 
-* `VALIDATOR_ID` - The ID of the validator requesting the signature.
+* `ENV_FILEPATH` - Path to the environment file for node configuration.
+
+Required environment variables in `ENV_FILEPATH`:
+
+* `FAIR_CONTRACTS` - Fair contracts alias or address (e.g., `mainnet`).
+* `NODE_VERSION` - Stream of `skale-node` configs (e.g., `fair-main`).
+* `BOOT_ENDPOINT` - RPC endpoint of the Fair network (e.g., `https://rpc.fair.cloud/`).
+* `SGX_SERVER_URL` - SGX server URL (e.g., `https://127.0.0.1:1026/`).
+* `DISK_MOUNTPOINT` - Mount point for storing data (e.g., `/dev/sdc`).
+* `ENV_TYPE` - Environment type (e.g., `mainnet`).
+
+Optional variables:
+
+* `ENFORCE_BTRFS` - Format existing filesystem on attached disk (`True`/`False`).
+* `FILEBEAT_HOST` - URL of the Filebeat log server to send logs.
+
+#### Fair Node Registration
+
+Register the Fair node with the specified IP address.
+
+```shell
+fair node register --ip <IP_ADDRESS>
+```
+
+Options:
+
+* `--ip` - Public IP address for the Fair node (required).
+
+#### Fair Node Update
+
+Update the Fair node software.
+
+```shell
+fair node update <ENV_FILEPATH> [--yes] [--pull-config SCHAIN]
+```
+
+Arguments:
+
+* `ENV_FILEPATH` - Path to the environment file for node configuration.
+
+Required environment variables in `ENV_FILEPATH`:
+
+* `FAIR_CONTRACTS` - Fair contracts alias or address (e.g., `mainnet`).
+* `NODE_VERSION` - Stream of `skale-node` configs (e.g., `fair-main`).
+* `BOOT_ENDPOINT` - RPC endpoint of the Fair network (e.g., `https://rpc.fair.cloud/`).
+* `SGX_SERVER_URL` - SGX server URL (e.g., `https://127.0.0.1:1026/`).
+* `DISK_MOUNTPOINT` - Mount point for storing data (e.g., `/dev/sdc`).
+* `ENV_TYPE` - Environment type (e.g., `mainnet`).
+
+Optional variables:
+
+* `ENFORCE_BTRFS` - Format existing filesystem on attached disk (`True`/`False`).
+* `FILEBEAT_HOST` - URL of the Filebeat log server to send logs.
+
+Options:
+
+* `--yes` - Update without confirmation prompt.
+* `--pull-config` - Pull configuration for specific sChain (hidden option).
+
+#### Fair Node Migrate
+
+Switch from boot phase to regular Fair node operation.
+
+```shell
+fair node migrate <ENV_FILEPATH> [--yes]
+```
+
+Arguments:
+
+* `ENV_FILEPATH` - Path to the environment file for node configuration.
+
+Required environment variables in `ENV_FILEPATH`:
+
+* `FAIR_CONTRACTS` - Fair contracts alias or address (e.g., `mainnet`).
+* `NODE_VERSION` - Stream of `skale-node` configs (e.g., `fair-main`).
+* `BOOT_ENDPOINT` - RPC endpoint of the Fair network (e.g., `https://rpc.fair.cloud/`).
+* `SGX_SERVER_URL` - SGX server URL (e.g., `https://127.0.0.1:1026/`).
+* `DISK_MOUNTPOINT` - Mount point for storing data (e.g., `/dev/sdc`).
+* `ENV_TYPE` - Environment type (e.g., `mainnet`).
+
+Optional variables:
+
+* `ENFORCE_BTRFS` - Format existing filesystem on attached disk (`True`/`False`).
+* `FILEBEAT_HOST` - URL of the Filebeat log server to send logs.
+
+Options:
+
+* `--yes` - Migrate without confirmation prompt.
+
+#### Fair Node Repair
+
+Toggle fair chain repair mode.
+
+```shell
+fair node repair [--snapshot-from SOURCE] [--yes]
+```
+
+Options:
+
+* `--snapshot-from` - Source for snapshots (`any` by default, hidden option).
+* `--yes` - Proceed without confirmation prompt.
 
 #### Fair Node Backup
 
@@ -822,12 +932,150 @@ fair node restore <BACKUP_PATH> <ENV_FILE> [--config-only]
 
 Arguments:
 
-* `BACKUP_PATH` - Path to the archive.
+* `BACKUP_PATH` - Path to the backup archive.
 * `ENV_FILE` - Path to the .env file for the restored node configuration.
 
 Options:
 
 * `--config-only` - Only restore configuration files.
+
+#### Fair Node Cleanup
+
+Cleanup Fair node data and configuration.
+
+```shell
+fair node cleanup [--yes]
+```
+
+Options:
+
+* `--yes` - Cleanup without confirmation prompt.
+
+#### Fair Node Change IP
+
+Change the IP address of the Fair node.
+
+```shell
+fair node change-ip <IP_ADDRESS>
+```
+
+Arguments:
+
+* `IP_ADDRESS` - New public IP address for the Fair node.
+
+### Fair Wallet commands
+
+> Prefix: `fair wallet`
+
+Commands for managing the node wallet.
+
+#### Fair Wallet Info
+
+Get information about the SKALE node wallet.
+
+```shell
+fair wallet info [--format FORMAT]
+```
+
+Options:
+
+* `--format`/`-f` - Output format (`json` or `text`).
+
+#### Fair Wallet Send
+
+Send ETH from SKALE node wallet to an address.
+
+```shell
+fair wallet send <ADDRESS> <AMOUNT> [--yes]
+```
+
+Arguments:
+
+* `ADDRESS` - Destination address for ETH transfer.
+* `AMOUNT` - Amount of ETH to send (as float).
+
+Options:
+
+* `--yes` - Send without confirmation prompt.
+
+### Fair Logs commands
+
+> Prefix: `fair logs`
+
+Commands for managing and accessing node logs.
+
+#### Fair CLI Logs
+
+Fetch the logs of the node-cli.
+
+```shell
+fair logs cli [--debug]
+```
+
+Options:
+
+* `--debug` - Show debug logs instead of regular logs.
+
+#### Fair Logs Dump
+
+Dump all logs from the connected node.
+
+```shell
+fair logs dump <PATH> [--container CONTAINER]
+```
+
+Arguments:
+
+* `PATH` - Path where the logs dump will be saved.
+
+Options:
+
+* `--container`/`-c` - Dump logs only from specified container.
+
+### Fair SSL commands
+
+> Prefix: `fair ssl`
+
+Commands for managing SSL certificates for sChains.
+
+#### Fair SSL Status
+
+Check the status of SSL certificates on the node.
+
+```shell
+fair ssl status
+```
+
+#### Fair SSL Upload
+
+Upload SSL certificate files to the node.
+
+```shell
+fair ssl upload --cert-path <CERT_PATH> --key-path <KEY_PATH> [--force]
+```
+
+Options:
+
+* `--cert-path`/`-c` - Path to the SSL certificate file (required).
+* `--key-path`/`-k` - Path to the SSL private key file (required).
+* `--force`/`-f` - Overwrite existing certificates.
+
+#### Fair SSL Check
+
+Check SSL certificate validity and connectivity.
+
+```shell
+fair ssl check [--cert-path CERT_PATH] [--key-path KEY_PATH] [--port PORT] [--type TYPE] [--no-client] [--no-wss]
+```
+
+Options:
+
+* `--cert-path`/`-c` - Path to the certificate file (default: system default).
+* `--key-path`/`-k` - Path to the key file (default: system default).
+* `--port`/`-p` - Port to start SSL health check server (default: from configuration).
+* `--type`/`-t` - Check type: `all`, `openssl`, or `skaled` (default: `all`).
+* `--no-client` - Skip client connection for openssl check.
+* `--no-wss` - Skip WSS server starting for skaled check.
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Ensure that the following packages are installed: **docker**, **docker-compose**
 This binary (`skale-VERSION-OS`) is used for managing standard SKALE validator nodes.
 
 ```shell
-# Replace {version} with the desired release version (e.g., 2.6.0)
-VERSION_NUM={version} && \
-sudo -E bash -c "curl -L https://github.com/skalenetwork/node-cli/releases/download/$VERSION_NUM/skale-$VERSION_NUM-`uname -s`-`uname -m` > /usr/local/bin/skale"
+# Replace {version} with the desired release version (e.g., 3.0.0)
+CLI_VERSION={version} && \
+sudo -E bash -c "curl -L https://github.com/skalenetwork/node-cli/releases/download/$CLI_VERSION/skale-$CLI_VERSION-`uname -s`-`uname -m` > /usr/local/bin/skale"
 ```
 
 ### Sync Node Binary
@@ -55,19 +55,19 @@ sudo -E bash -c "curl -L https://github.com/skalenetwork/node-cli/releases/downl
 This binary (`skale-VERSION-OS-sync`) is used for managing dedicated Sync nodes. **Ensure you download the correct `-sync` suffixed binary for Sync node operations.**
 
 ```shell
-# Replace {version} with the desired release version (e.g., 2.6.0)
-VERSION_NUM={version} && \
-sudo -E bash -c "curl -L https://github.com/skalenetwork/node-cli/releases/download/$VERSION_NUM/skale-$VERSION_NUM-`uname -s`-`uname -m`-sync > /usr/local/bin/skale"
+# Replace {version} with the desired release version (e.g., 3.0.0)
+CLI_VERSION={version} && \
+sudo -E bash -c "curl -L https://github.com/skalenetwork/node-cli/releases/download/$CLI_VERSION/skale-$CLI_VERSION-`uname -s`-`uname -m`-sync > /usr/local/bin/skale"
 ```
 
 ### Fair Node Binary
 
-This binary (`skale-VERSION-OS-fair`) is used specifically for managing nodes on the Fair network. It is named `fair`.
+This binary (`skale-VERSION-OS-fair`) is used specifically for managing nodes on the Fair network.
 
 ```shell
-# Replace {version} with the desired release version (e.g., 2.6.0)
-VERSION_NUM={version} && \
-sudo -E bash -c "curl -L https://github.com/skalenetwork/node-cli/releases/download/$VERSION_NUM/skale-$VERSION_NUM-`uname -s`-`uname -m`-fair > /usr/local/bin/fair"
+# Replace {version} with the desired release version (e.g., 3.0.0)
+CLI_VERSION={version} && \
+sudo -E bash -c "curl -L https://github.com/skalenetwork/node-cli/releases/download/$CLI_VERSION/skale-$CLI_VERSION-`uname -s`-`uname -m`-fair > /usr/local/bin/fair"
 ```
 
 ### Permissions and Testing
@@ -155,7 +155,7 @@ Required environment variables in `ENV_FILE`:
 * `SGX_SERVER_URL` - SGX server URL.
 * `DISK_MOUNTPOINT` - Mount point for storing sChains data.
 * `DOCKER_LVMPY_STREAM` - Stream of `docker-lvmpy` to use.
-* `CONTAINER_CONFIGS_STREAM` - Stream of `skale-node` to use.
+* `NODE_VERSION` - Stream of `skale-node` to use.
 * `ENDPOINT` - RPC endpoint of the network where SKALE Manager is deployed.
 * `MANAGER_CONTRACTS` - SKALE Manager `message_proxy_mainnet` contract alias or address.
 * `IMA_CONTRACTS` - IMA `skale_manager` contract alias or address.
@@ -595,7 +595,7 @@ Required environment variables in `ENV_FILE`:
 
 * `DISK_MOUNTPOINT` - Mount point for storing sChain data.
 * `DOCKER_LVMPY_STREAM` - Stream of `docker-lvmpy`.
-* `CONTAINER_CONFIGS_STREAM` - Stream of `skale-node`.
+* `NODE_VERSION` - Stream of `skale-node`.
 * `ENDPOINT` - RPC endpoint of the network where SKALE Manager is deployed.
 * `MANAGER_CONTRACTS` - SKALE Manager alias or address.
 * `IMA_CONTRACTS` - IMA alias or address.
@@ -695,7 +695,7 @@ Required environment variables in `ENV_FILE`:
 
 * `SGX_SERVER_URL` - SGX server URL.
 * `DISK_MOUNTPOINT` - Mount point for storing data (BTRFS recommended).
-* `CONTAINER_CONFIGS_STREAM` - Stream of `skale-node` configs.
+* `NODE_VERSION` - Stream of `skale-node` configs.
 * `ENDPOINT` - RPC endpoint of the network where Fair Manager is deployed.
 * `MANAGER_CONTRACTS` - SKALE Manager alias or address.
 * `IMA_CONTRACTS` - IMA alias or address (*Note: Required by boot service, may not be used by Fair itself*).

--- a/node_cli/cli/fair_node.py
+++ b/node_cli/cli/fair_node.py
@@ -76,9 +76,14 @@ def register(ip: str) -> None:
     prompt='Are you sure you want to update Fair node software?',
 )
 @click.option('--pull-config', 'pull_config_for_schain', hidden=True, type=str)
+@click.option('--force-skaled-start', 'force_skaled_start', hidden=True, type=bool, default=False)
 @streamed_cmd
-def update_node(env_filepath: str, pull_config_for_schain):
-    update_fair(env_filepath=env_filepath, pull_config_for_schain=pull_config_for_schain)
+def update_node(env_filepath: str, pull_config_for_schain, force_skaled_start: bool):
+    update_fair(
+        env_filepath=env_filepath,
+        pull_config_for_schain=pull_config_for_schain,
+        force_skaled_start=force_skaled_start,
+    )
 
 
 @node.command('backup', help='Generate backup file for the Fair node.')

--- a/node_cli/cli/fair_node.py
+++ b/node_cli/cli/fair_node.py
@@ -76,7 +76,14 @@ def register(ip: str) -> None:
     prompt='Are you sure you want to update Fair node software?',
 )
 @click.option('--pull-config', 'pull_config_for_schain', hidden=True, type=str)
-@click.option('--force-skaled-start', 'force_skaled_start', hidden=True, type=bool, default=False)
+@click.option(
+    '--force-skaled-start',
+    'force_skaled_start',
+    hidden=True,
+    type=bool,
+    default=False,
+    is_flag=True,
+)
 @streamed_cmd
 def update_node(env_filepath: str, pull_config_for_schain, force_skaled_start: bool):
     update_fair(

--- a/node_cli/configs/user.py
+++ b/node_cli/configs/user.py
@@ -44,7 +44,7 @@ class ValidationResult(NamedTuple):
 
 @dataclass(kw_only=True)
 class BaseUserConfig(ABC):
-    container_configs_stream: str
+    node_version: str
     env_type: str
     filebeat_host: str
     disk_mountpoint: str

--- a/node_cli/fair/fair_node.py
+++ b/node_cli/fair/fair_node.py
@@ -103,8 +103,15 @@ def migrate_from_boot(
 
 @check_inited
 @check_user
-def update(env_filepath: str, pull_config_for_schain: str | None = None) -> None:
-    logger.info('Updating fair node...')
+def update(
+    env_filepath: str, pull_config_for_schain: str | None = None, force_skaled_start: bool = False
+) -> None:
+    logger.info(
+        'Updating fair node: %s, pull_config_for_schain: %s, force_skaled_start: %s',
+        env_filepath,
+        pull_config_for_schain,
+        force_skaled_start,
+    )
     env = compose_node_env(
         env_filepath,
         inited_node=True,
@@ -112,7 +119,12 @@ def update(env_filepath: str, pull_config_for_schain: str | None = None) -> None
         node_type=NodeType.FAIR,
         pull_config_for_schain=pull_config_for_schain,
     )
-    update_ok = update_fair_op(env_filepath, env, update_type=FairUpdateType.REGULAR)
+    update_ok = update_fair_op(
+        env_filepath,
+        env,
+        update_type=FairUpdateType.REGULAR,
+        force_skaled_start=force_skaled_start,
+    )
     alive = is_base_containers_alive(node_type=NodeType.FAIR)
     if not update_ok or not alive:
         print_node_cmd_error()

--- a/node_cli/fair/record/chain_record.py
+++ b/node_cli/fair/record/chain_record.py
@@ -75,7 +75,7 @@ def get_fair_chain_record(env: dict) -> ChainRecord:
 
 
 def migrate_chain_record(env: dict) -> None:
-    version = env['CONTAINER_CONFIGS_STREAM']
+    version = env['NODE_VERSION']
     logger.info('Migrating fair chain record, setting config version to %s', version)
     record = get_fair_chain_record(env)
     record.set_config_version(version)

--- a/node_cli/fair/record/chain_record.py
+++ b/node_cli/fair/record/chain_record.py
@@ -34,6 +34,7 @@ CHAIN_RECORD_FIELDS: dict[str, FieldInfo] = {
     'repair_date': FieldInfo('repair_date', datetime, datetime.fromtimestamp(0)),
     'repair_ts': FieldInfo('repair_ts', int, None),
     'snapshot_from': FieldInfo('snapshot_from', str, None),
+    'force_skaled_start': FieldInfo('force_skaled_start', bool, False),
 }
 
 
@@ -57,6 +58,10 @@ class ChainRecord(FlatRedisRecord):
     def repair_ts(self) -> int | None:
         return cast(int | None, self._get_field('repair_ts'))
 
+    @property
+    def force_skaled_start(self) -> bool:
+        return cast(bool, self._get_field('force_skaled_start'))
+
     def set_config_version(self, version: str) -> None:
         self._set_field('config_version', version)
 
@@ -69,6 +74,9 @@ class ChainRecord(FlatRedisRecord):
     def set_repair_ts(self, value: int | None) -> None:
         self._set_field('repair_ts', value)
 
+    def set_force_skaled_start(self, value: bool) -> None:
+        self._set_field('force_skaled_start', value)
+
 
 def get_fair_chain_record(env: dict) -> ChainRecord:
     return ChainRecord(get_fair_chain_name(env))
@@ -79,3 +87,9 @@ def migrate_chain_record(env: dict) -> None:
     logger.info('Migrating fair chain record, setting config version to %s', version)
     record = get_fair_chain_record(env)
     record.set_config_version(version)
+
+
+def update_chain_record(env: dict, force_skaled_start: bool) -> None:
+    record = get_fair_chain_record(env)
+    record.set_force_skaled_start(force_skaled_start)
+    logger.info('Updated fair chain record with force_skaled_start=%s', force_skaled_start)

--- a/node_cli/operations/base.py
+++ b/node_cli/operations/base.py
@@ -76,7 +76,7 @@ logger = logging.getLogger(__name__)
 def checked_host(func):
     @functools.wraps(func)
     def wrapper(env_filepath: str, env: Dict, *args, **kwargs):
-        download_skale_node(env.get('CONTAINER_CONFIGS_STREAM'), env.get('CONTAINER_CONFIGS_DIR'))
+        download_skale_node(env.get('NODE_VERSION'), env.get('CONTAINER_CONFIGS_DIR'))
         failed_checks = run_host_checks(
             env['DISK_MOUNTPOINT'],
             TYPE,
@@ -130,17 +130,17 @@ def update(env_filepath: str, env: Dict, node_type: NodeType) -> bool:
     meta_manager = CliMetaManager()
     current_stream = meta_manager.get_meta_info().config_stream
     skip_cleanup = env.get('SKIP_DOCKER_CLEANUP') == 'True'
-    if not skip_cleanup and current_stream != env['CONTAINER_CONFIGS_STREAM']:
+    if not skip_cleanup and current_stream != env['NODE_VERSION']:
         logger.info(
             'Stream version was changed from %s to %s',
             current_stream,
-            env['CONTAINER_CONFIGS_STREAM'],
+            env['NODE_VERSION'],
         )
         docker_cleanup()
 
     meta_manager.update_meta(
         VERSION,
-        env['CONTAINER_CONFIGS_STREAM'],
+        env['NODE_VERSION'],
         env['DOCKER_LVMPY_STREAM'],
         distro.id(),
         distro.version(),
@@ -173,17 +173,17 @@ def update_fair_boot(env_filepath: str, env: Dict) -> bool:
     meta_manager = FairCliMetaManager()
     current_stream = meta_manager.get_meta_info().config_stream
     skip_cleanup = env.get('SKIP_DOCKER_CLEANUP') == 'True'
-    if not skip_cleanup and current_stream != env['CONTAINER_CONFIGS_STREAM']:
+    if not skip_cleanup and current_stream != env['NODE_VERSION']:
         logger.info(
             'Stream version was changed from %s to %s',
             current_stream,
-            env['CONTAINER_CONFIGS_STREAM'],
+            env['NODE_VERSION'],
         )
         docker_cleanup()
 
     meta_manager.update_meta(
         VERSION,
-        env['CONTAINER_CONFIGS_STREAM'],
+        env['NODE_VERSION'],
         distro.id(),
         distro.version(),
     )
@@ -216,7 +216,7 @@ def init(env_filepath: str, env: dict, node_type: NodeType) -> None:
     meta_manager = CliMetaManager()
     meta_manager.update_meta(
         VERSION,
-        env['CONTAINER_CONFIGS_STREAM'],
+        env['NODE_VERSION'],
         env['DOCKER_LVMPY_STREAM'],
         distro.id(),
         distro.version(),
@@ -250,7 +250,7 @@ def init_fair_boot(env_filepath: str, env: dict) -> None:
     meta_manager = FairCliMetaManager()
     meta_manager.update_meta(
         VERSION,
-        env['CONTAINER_CONFIGS_STREAM'],
+        env['NODE_VERSION'],
         distro.id(),
         distro.version(),
     )
@@ -268,7 +268,7 @@ def init_sync(
     snapshot_from: Optional[str],
 ) -> None:
     cleanup_volume_artifacts(env['DISK_MOUNTPOINT'])
-    download_skale_node(env.get('CONTAINER_CONFIGS_STREAM'), env.get('CONTAINER_CONFIGS_DIR'))
+    download_skale_node(env.get('NODE_VERSION'), env.get('CONTAINER_CONFIGS_DIR'))
     sync_skale_node()
 
     if env.get('SKIP_DOCKER_CONFIG') != 'True':
@@ -296,7 +296,7 @@ def init_sync(
     meta_manager = CliMetaManager()
     meta_manager.update_meta(
         VERSION,
-        env['CONTAINER_CONFIGS_STREAM'],
+        env['NODE_VERSION'],
         None,
         distro.id(),
         distro.version(),
@@ -317,7 +317,7 @@ def update_sync(env_filepath: str, env: Dict) -> bool:
     compose_rm(env=env, node_type=NodeType.SYNC)
     remove_dynamic_containers()
     cleanup_volume_artifacts(env['DISK_MOUNTPOINT'])
-    download_skale_node(env['CONTAINER_CONFIGS_STREAM'], env.get('CONTAINER_CONFIGS_DIR'))
+    download_skale_node(env['NODE_VERSION'], env.get('CONTAINER_CONFIGS_DIR'))
     sync_skale_node()
 
     if env.get('SKIP_DOCKER_CONFIG') != 'True':
@@ -336,7 +336,7 @@ def update_sync(env_filepath: str, env: Dict) -> bool:
     meta_manager = CliMetaManager()
     meta_manager.update_meta(
         VERSION,
-        env['CONTAINER_CONFIGS_STREAM'],
+        env['NODE_VERSION'],
         env['DOCKER_LVMPY_STREAM'],
         distro.id(),
         distro.version(),
@@ -359,7 +359,7 @@ def turn_on(env: dict, node_type: NodeType) -> None:
     meta_manager = CliMetaManager()
     meta_manager.update_meta(
         VERSION,
-        env['CONTAINER_CONFIGS_STREAM'],
+        env['NODE_VERSION'],
         env['DOCKER_LVMPY_STREAM'],
         distro.id(),
         distro.version(),
@@ -402,7 +402,7 @@ def restore(env, backup_path, node_type: NodeType, config_only=False):
     meta_manager = CliMetaManager()
     meta_manager.update_meta(
         VERSION,
-        env['CONTAINER_CONFIGS_STREAM'],
+        env['NODE_VERSION'],
         env['DOCKER_LVMPY_STREAM'],
         distro.id(),
         distro.version(),

--- a/node_cli/operations/fair.py
+++ b/node_cli/operations/fair.py
@@ -38,7 +38,11 @@ from node_cli.core.nftables import configure_nftables
 from node_cli.core.nginx import generate_nginx_config
 from node_cli.core.schains import cleanup_no_lvm_datadir
 from node_cli.core.static_config import get_fair_chain_name
-from node_cli.fair.record.chain_record import get_fair_chain_record, migrate_chain_record
+from node_cli.fair.record.chain_record import (
+    get_fair_chain_record,
+    migrate_chain_record,
+    update_chain_record,
+)
 from node_cli.migrations.fair.from_boot import migrate_nftables_from_boot
 from node_cli.operations.base import checked_host, turn_off
 from node_cli.operations.common import configure_filebeat, configure_flask, unpack_backup_archive
@@ -149,7 +153,12 @@ def update_fair_boot(env_filepath: str, env: dict) -> bool:
 
 
 @checked_host
-def update(env_filepath: str, env: dict, update_type: FairUpdateType) -> bool:
+def update(
+    env_filepath: str,
+    env: dict,
+    update_type: FairUpdateType,
+    force_skaled_start: bool,
+) -> bool:
     compose_rm(node_type=NodeType.FAIR, env=env)
     if update_type not in (FairUpdateType.INFRA_ONLY, FairUpdateType.FROM_BOOT):
         remove_dynamic_containers()
@@ -193,7 +202,7 @@ def update(env_filepath: str, env: dict, update_type: FairUpdateType) -> bool:
     time.sleep(REDIS_START_TIMEOUT)
     if update_type == FairUpdateType.FROM_BOOT:
         migrate_chain_record(env)
-
+    update_chain_record(env, force_skaled_start=force_skaled_start)
     compose_up(env=env, node_type=NodeType.FAIR)
     return True
 

--- a/node_cli/operations/fair.py
+++ b/node_cli/operations/fair.py
@@ -95,7 +95,7 @@ def init(env_filepath: str, env: dict) -> bool:
     meta_manager = FairCliMetaManager()
     meta_manager.update_meta(
         VERSION,
-        env['CONTAINER_CONFIGS_STREAM'],
+        env['NODE_VERSION'],
         distro.id(),
         distro.version(),
     )
@@ -129,17 +129,17 @@ def update_fair_boot(env_filepath: str, env: dict) -> bool:
     meta_manager = FairCliMetaManager()
     current_stream = meta_manager.get_meta_info().config_stream
     skip_cleanup = env.get('SKIP_DOCKER_CLEANUP') == 'True'
-    if not skip_cleanup and current_stream != env['CONTAINER_CONFIGS_STREAM']:
+    if not skip_cleanup and current_stream != env['NODE_VERSION']:
         logger.info(
             'Stream version was changed from %s to %s',
             current_stream,
-            env['CONTAINER_CONFIGS_STREAM'],
+            env['NODE_VERSION'],
         )
         docker_cleanup()
 
     meta_manager.update_meta(
         VERSION,
-        env['CONTAINER_CONFIGS_STREAM'],
+        env['NODE_VERSION'],
         distro.id(),
         distro.version(),
     )
@@ -167,17 +167,17 @@ def update(env_filepath: str, env: dict, update_type: FairUpdateType) -> bool:
     meta_manager = FairCliMetaManager()
     current_stream = meta_manager.get_meta_info().config_stream
     skip_cleanup = env.get('SKIP_DOCKER_CLEANUP') == 'True'
-    if not skip_cleanup and current_stream != env['CONTAINER_CONFIGS_STREAM']:
+    if not skip_cleanup and current_stream != env['NODE_VERSION']:
         logger.info(
             'Stream version was changed from %s to %s',
             current_stream,
-            env['CONTAINER_CONFIGS_STREAM'],
+            env['NODE_VERSION'],
         )
         docker_cleanup()
 
     meta_manager.update_meta(
         VERSION,
-        env['CONTAINER_CONFIGS_STREAM'],
+        env['NODE_VERSION'],
         distro.id(),
         distro.version(),
     )
@@ -224,7 +224,7 @@ def restore(env, backup_path, config_only=False):
     meta_manager = FairCliMetaManager()
     meta_manager.update_meta(
         VERSION,
-        env['CONTAINER_CONFIGS_STREAM'],
+        env['NODE_VERSION'],
         distro.id(),
         distro.version(),
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,7 +242,7 @@ def valid_env_params():
         'DB_USER': 'user',
         'DB_PASSWORD': 'pass',
         'DB_PORT': '3307',
-        'CONTAINER_CONFIGS_STREAM': 'master',
+        'NODE_VERSION': 'master',
         'FILEBEAT_HOST': '127.0.0.1:3010',
         'SGX_SERVER_URL': 'http://127.0.0.1',
         'DISK_MOUNTPOINT': '/dev/sss',
@@ -307,7 +307,7 @@ def regular_user_conf(tmp_path):
     try:
         test_env = """
         ENDPOINT=http://localhost:8545
-        CONTAINER_CONFIGS_STREAM='main'
+        NODE_VERSION='main'
         FILEBEAT_HOST=127.0.0.1:3010
         SGX_SERVER_URL=http://127.0.0.1
         DISK_MOUNTPOINT=/dev/sss
@@ -329,7 +329,7 @@ def fair_user_conf(tmp_path):
     try:
         test_env = """
         BOOT_ENDPOINT=http://localhost:8545
-        CONTAINER_CONFIGS_STREAM='main'
+        NODE_VERSION='main'
         FILEBEAT_HOST=127.0.0.1:3010
         SGX_SERVER_URL=http://127.0.0.1
         DISK_MOUNTPOINT=/dev/sss
@@ -350,7 +350,7 @@ def fair_boot_user_conf(tmp_path):
     try:
         test_env = """
         ENDPOINT=http://localhost:8545
-        CONTAINER_CONFIGS_STREAM='main'
+        NODE_VERSION='main'
         FILEBEAT_HOST=127.0.0.1:3010
         SGX_SERVER_URL=http://127.0.0.1
         DISK_MOUNTPOINT=/dev/sss
@@ -371,7 +371,7 @@ def sync_user_conf(tmp_path):
     try:
         test_env = """
         ENDPOINT=http://localhost:8545
-        CONTAINER_CONFIGS_STREAM='main'
+        NODE_VERSION='main'
         FILEBEAT_HOST=127.0.0.1:3010
         DISK_MOUNTPOINT=/dev/sss
         ENV_TYPE='devnet'


### PR DESCRIPTION
This pull request introduces significant updates to the SKALE Node CLI documentation and codebase, focusing on enhancing functionality, improving clarity, and standardizing configuration variables. Key changes include the addition of new commands for node and wallet management, updates to environment variable naming, and adjustments to the codebase to align with these changes.

### Documentation Enhancements:
* Added new command categories (`Fair Wallet`, `Fair Logs`, and `Fair SSL`) with detailed descriptions and usage examples in `README.md`. These include commands for managing wallets, logs, and SSL certificates. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32-R34) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L825-R1079)
* Updated the `Fair Boot` and `Fair Node` sections with new commands like `info`, `update`, `cleanup`, and `change-ip`, providing clearer guidance for node lifecycle management. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R685-R713) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L717-R741)

### Environment Variable Standardization:
* Renamed the `CONTAINER_CONFIGS_STREAM` environment variable to `NODE_VERSION` across documentation and code for consistency and clarity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L158-R161) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L598-R601) [[3]](diffhunk://#diff-f3abb734bd46614e5fda5d5ba9785676d736559df41db30ba7e6a73747c578b6L47-R47)

### Codebase Updates:
* Updated all references to `CONTAINER_CONFIGS_STREAM` in the codebase to use `NODE_VERSION`, ensuring alignment with the new naming convention. This affects functions like `update`, `init`, and `turn_on` in `node_cli/operations/base.py`. [[1]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L79-R79) [[2]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L133-R143) [[3]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L176-R186) [[4]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L253-R253) [[5]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L362-R362)
* Adjusted the logic in `migrate_chain_record` and related methods to reflect the renamed variable.

These changes improve the usability and maintainability of the SKALE Node CLI, providing a more streamlined experience for users and developers.