### PR TITLE
Add node exit command

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,16 @@
+- always keep the changes minimal and purposeful
+- focus on fixing the exact problem or implementing the exact feature
+- keep the code simple, do not write defensive code
+- do not describe your changes in details after you made changes, focus on writing code
+- do not generate any documentation, the code should be self-explanatory
+- do not generate any in-line comments
+- for the new files, always add a license header, same format as in the existing files
+- no commented out code
+- no console logs in production code
+- no unused imports
+- no redundant code - move repeated logic into helper functions
+- use type hints to specify the expected types of function arguments and return values
+
+- check `ruff.toml` for formatting rules
+- always lint changes using `ruff check`
+- tests should be placed in `tests/` directory, follow the existing structure and code style

--- a/node_cli/cli/fair_node.py
+++ b/node_cli/cli/fair_node.py
@@ -22,6 +22,7 @@ import click
 from node_cli.core.node import backup
 from node_cli.fair.fair_node import change_ip as change_ip_fair
 from node_cli.fair.fair_node import cleanup as fair_cleanup
+from node_cli.fair.fair_node import exit as exit_fair
 from node_cli.fair.fair_node import (
     get_node_info,
     migrate_from_boot,
@@ -165,3 +166,15 @@ def cleanup_node():
 @click.argument('ip', type=IP_TYPE)
 def change_ip(ip: str) -> None:
     change_ip_fair(ip=ip)
+
+
+@node.command('exit', help=TEXTS['fair']['node']['exit']['help'])
+@click.option(
+    '--yes',
+    is_flag=True,
+    callback=abort_if_false,
+    expose_value=False,
+    prompt=TEXTS['fair']['node']['exit']['prompt'],
+)
+def exit_node() -> None:
+    exit_fair()

--- a/node_cli/cli/fair_node.py
+++ b/node_cli/cli/fair_node.py
@@ -164,6 +164,7 @@ def cleanup_node():
 
 @node.command('change-ip', help=TEXTS['fair']['node']['change-ip']['help'])
 @click.argument('ip', type=IP_TYPE)
+@streamed_cmd
 def change_ip(ip: str) -> None:
     change_ip_fair(ip=ip)
 
@@ -176,5 +177,6 @@ def change_ip(ip: str) -> None:
     expose_value=False,
     prompt=TEXTS['fair']['node']['exit']['prompt'],
 )
+@streamed_cmd
 def exit_node() -> None:
     exit_fair()

--- a/node_cli/configs/routes.py
+++ b/node_cli/configs/routes.py
@@ -40,7 +40,7 @@ ROUTES = {
         'schains': ['config', 'list', 'dkg-statuses', 'firewall-rules', 'repair', 'get'],
         'ssl': ['status', 'upload'],
         'wallet': ['info', 'send-eth'],
-        'fair-node': ['info', 'register', 'change-ip'],
+        'fair-node': ['info', 'register', 'change-ip', 'exit'],
     }
 }
 

--- a/node_cli/fair/fair_node.py
+++ b/node_cli/fair/fair_node.py
@@ -92,7 +92,9 @@ def migrate_from_boot(
         sync_schains=False,
         node_type=NodeType.FAIR,
     )
-    migrate_ok = update_fair_op(env_filepath, env, update_type=FairUpdateType.FROM_BOOT)
+    migrate_ok = update_fair_op(
+        env_filepath, env, update_type=FairUpdateType.FROM_BOOT, force_skaled_start=False
+    )
     alive = is_base_containers_alive(node_type=NodeType.FAIR)
     if not migrate_ok or not alive:
         print_node_cmd_error()
@@ -196,4 +198,22 @@ def change_ip(ip: str) -> None:
     else:
         error_msg = payload
         logger.error(f'Change IP error {error_msg}')
+        error_exit(error_msg, exit_code=CLIExitCodes.BAD_API_RESPONSE)
+
+
+@check_inited
+@check_user
+def exit() -> None:
+    if not is_node_inited():
+        print(TEXTS['fair']['node']['not_inited'])
+        return
+
+    status, payload = post_request(blueprint=BLUEPRINT_NAME, method='exit', json={})
+    if status == 'ok':
+        msg = TEXTS['fair']['node']['exited']
+        logger.info(msg)
+        print(msg)
+    else:
+        error_msg = payload
+        logger.error(f'Node exit error {error_msg}')
         error_exit(error_msg, exit_code=CLIExitCodes.BAD_API_RESPONSE)

--- a/tests/cli/fair_cli_test.py
+++ b/tests/cli/fair_cli_test.py
@@ -11,6 +11,7 @@ from node_cli.cli.fair_boot import (
 from node_cli.cli.fair_node import (
     backup_node,
     migrate_node,
+    exit_node,
     restore_node,
 )
 
@@ -101,3 +102,12 @@ def test_fair_node_migrate(mock_migrate_core, valid_env_file):
 
     assert result.exit_code == 0, f'Output: {result.output}\nException: {result.exception}'
     mock_migrate_core.assert_called_once_with(env_filepath=valid_env_file)
+
+
+@mock.patch('node_cli.cli.fair_node.exit_fair')
+def test_fair_node_exit(mock_exit_core):
+    runner = CliRunner()
+    result = runner.invoke(exit_node, ['--yes'])
+
+    assert result.exit_code == 0, f'Output: {result.output}\nException: {result.exception}'
+    mock_exit_core.assert_called_once()

--- a/tests/fair/fair_node_test.py
+++ b/tests/fair/fair_node_test.py
@@ -125,7 +125,7 @@ def test_migrate_from_boot(
         node_type=NodeType.FAIR,
     )
     mock_migrate_op.assert_called_once_with(
-        valid_env_file, mock_env, update_type=FairUpdateType.FROM_BOOT
+        valid_env_file, mock_env, update_type=FairUpdateType.FROM_BOOT, force_skaled_start=False
     )
 
 

--- a/tests/fair/fair_node_test.py
+++ b/tests/fair/fair_node_test.py
@@ -257,3 +257,65 @@ def test_cleanup_logs_success_message(
     mock_logger.info.assert_called_once_with(
         'Fair node was cleaned up, all containers and data removed'
     )
+
+
+@mock.patch('node_cli.utils.decorators.is_user_valid', return_value=True)
+@mock.patch('node_cli.fair.fair_node.post_request')
+@mock.patch('node_cli.fair.fair_node.is_node_inited', return_value=True)
+def test_exit_success(
+    mock_is_inited,
+    mock_post_request,
+    mock_is_user_valid,
+    inited_node,
+    resource_alloc,
+    meta_file_v3,
+):
+    from node_cli.fair.fair_node import exit
+
+    mock_post_request.return_value = ('ok', {})
+
+    exit()
+
+    mock_post_request.assert_called_once_with(blueprint='fair-node', method='exit', json={})
+
+
+@mock.patch('node_cli.utils.decorators.is_user_valid', return_value=True)
+@mock.patch('node_cli.fair.fair_node.error_exit')
+@mock.patch('node_cli.fair.fair_node.post_request')
+@mock.patch('node_cli.fair.fair_node.is_node_inited', return_value=True)
+def test_exit_error(
+    mock_is_inited,
+    mock_post_request,
+    mock_error_exit,
+    mock_is_user_valid,
+    inited_node,
+    resource_alloc,
+    meta_file_v3,
+):
+    from node_cli.fair.fair_node import exit
+
+    error_msg = 'Exit failed'
+    mock_post_request.return_value = ('error', error_msg)
+
+    exit()
+
+    mock_post_request.assert_called_once_with(blueprint='fair-node', method='exit', json={})
+    mock_error_exit.assert_called_once_with(error_msg, exit_code=mock.ANY)
+
+
+@mock.patch('node_cli.utils.decorators.is_user_valid', return_value=True)
+@mock.patch('node_cli.fair.fair_node.is_node_inited', return_value=False)
+def test_exit_not_inited(
+    mock_is_inited,
+    mock_is_user_valid,
+    inited_node,
+    resource_alloc,
+    meta_file_v3,
+    capsys,
+):
+    from node_cli.fair.fair_node import exit
+
+    exit()
+
+    captured = capsys.readouterr()
+    assert 'Node should be initialized to proceed with operation' in captured.out

--- a/tests/routes_test.py
+++ b/tests/routes_test.py
@@ -34,6 +34,7 @@ ALL_V1_ROUTES = [
     '/api/v1/fair-node/info',
     '/api/v1/fair-node/register',
     '/api/v1/fair-node/change-ip',
+    '/api/v1/fair-node/exit',
 ]
 
 

--- a/text.yml
+++ b/text.yml
@@ -94,3 +94,7 @@ fair:
     ip_changed: Node IP changed in Fair manager
     change-ip:
       help: Change the node IP in Fair manager
+    exited: Node removed from Fair manager
+    exit:
+      help: Remove node from Fair manager
+      prompt: Are you sure you want to remove the node from Fair manager?


### PR DESCRIPTION
This pull request introduces a new "exit" command to the Fair Node CLI, along with supporting functionality and tests. The changes also include updates to developer guidelines and minor improvements to existing functionality.

### New "Exit" Command for Fair Node CLI:

* Added `exit` command in `node_cli/cli/fair_node.py` to allow users to remove a node from the Fair manager. The command includes a confirmation prompt and uses the `exit_fair` function to handle the operation. [[1]](diffhunk://#diff-2f82f30c374ab8a51e09163549a12b05544deb7793f40e09c028aa2457d91364R169-R180) [[2]](diffhunk://#diff-59b2555c4af1bb922282c47c13a5be19fecf4f52cb5b4df19f8d461cd89768bfR202-R219)
* Implemented `exit` function in `node_cli/fair/fair_node.py` to handle the backend logic for removing a node, including validation checks and API requests.
* Updated `text.yml` to include help text and confirmation prompt for the new "exit" command.

### Testing Enhancements:

* Added unit tests in `tests/cli/fair_cli_test.py` to validate the CLI behavior of the "exit" command, including successful execution and proper mocking of the backend function.
* Added unit tests in `tests/fair/fair_node_test.py` to ensure the `exit` function handles success, error, and "not initialized" scenarios correctly.

### Developer Guidelines Update:

* Updated `.github/copilot-instructions.md` with additional coding guidelines, such as avoiding redundant code, using type hints, and ensuring tests follow the existing structure.

### Minor Improvements:

* Updated `migrate_from_boot` in `node_cli/fair/fair_node.py` to include a new parameter `force_skaled_start` in the `update_fair_op` call for improved flexibility.