### PR TITLE
Add fair chain commands - checks and record

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ SKALE Node CLI, part of the SKALE suite of validator tools, is the command line 
    1. [Top level commands (Fair)](#top-level-commands-fair)
    2. [Fair Boot commands](#fair-boot-commands)
    3. [Fair Node commands](#fair-node-commands)
-   4. [Fair Wallet commands](#fair-wallet-commands)
-   5. [Fair Logs commands](#fair-logs-commands)
-   6. [Fair SSL commands](#fair-ssl-commands)
+   4. [Fair Chain commands](#fair-chain-commands)
+   5. [Fair Wallet commands](#fair-wallet-commands)
+   6. [Fair Logs commands](#fair-logs-commands)
+   7. [Fair SSL commands](#fair-ssl-commands)
 5. [Exit codes](#exit-codes)
 6. [Development](#development)
 
@@ -841,7 +842,7 @@ Options:
 Update the Fair node software.
 
 ```shell
-fair node update <ENV_FILEPATH> [--yes] [--pull-config SCHAIN]
+fair node update <ENV_FILEPATH> [--yes] [--force-skaled-start]
 ```
 
 Arguments:
@@ -865,7 +866,7 @@ Optional variables:
 Options:
 
 * `--yes` - Update without confirmation prompt.
-* `--pull-config` - Pull configuration for specific sChain (hidden option).
+* `--force-skaled-start` - Force skaled container to start (hidden option).
 
 #### Fair Node Migrate
 
@@ -962,6 +963,36 @@ fair node change-ip <IP_ADDRESS>
 Arguments:
 
 * `IP_ADDRESS` - New public IP address for the Fair node.
+
+### Fair Chain commands
+
+> Prefix: `fair chain`
+
+Commands for managing and monitoring the Fair chain state and configuration.
+
+#### Fair Chain Record
+
+Get information about the Fair chain record, including chain name, configuration status, DKG status, and operational metadata.
+
+```shell
+fair chain record [--json]
+```
+
+Options:
+
+* `--json` - Output in JSON format instead of formatted table.
+
+#### Fair Chain Checks
+
+Get the status of Fair chain checks, including configuration checks and skaled checks.
+
+```shell
+fair chain checks [--json]
+```
+
+Options:
+
+* `--json` - Output in JSON format instead of formatted table.
 
 ### Fair Wallet commands
 

--- a/node_cli/cli/chain.py
+++ b/node_cli/cli/chain.py
@@ -1,0 +1,44 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of node-cli
+#
+#   Copyright (C) 2025-Present SKALE Labs
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import click
+
+from node_cli.fair.chain import get_chain_record, get_chain_checks
+
+
+@click.group()
+def chain_cli():
+    pass
+
+
+@chain_cli.group(help='Fair chain commands')
+def chain():
+    pass
+
+
+@chain.command('record', help='Get Fair chain record information')
+@click.option('--json', 'raw', is_flag=True, help='Output in JSON format')
+def chain_record(raw: bool) -> None:
+    get_chain_record(raw=raw)
+
+
+@chain.command('checks', help='Get Fair chain checks status')
+@click.option('--json', 'raw', is_flag=True, help='Output in JSON format')
+def chain_checks(raw: bool) -> None:
+    get_chain_checks(raw=raw)

--- a/node_cli/cli/ssl.py
+++ b/node_cli/cli/ssl.py
@@ -82,7 +82,7 @@ def upload(key_path, cert_path, force):
 @click.option(
     '--port',
     '-p',
-    help='Port to start ssl healtcheck server',
+    help='Port to start ssl healthcheck server',
     type=int,
     default=DEFAULT_SSL_CHECK_PORT,
 )

--- a/node_cli/configs/routes.py
+++ b/node_cli/configs/routes.py
@@ -41,6 +41,7 @@ ROUTES = {
         'ssl': ['status', 'upload'],
         'wallet': ['info', 'send-eth'],
         'fair-node': ['info', 'register', 'change-ip', 'exit'],
+        'fair-chain': ['record', 'checks'],
     }
 }
 

--- a/node_cli/fair/chain.py
+++ b/node_cli/fair/chain.py
@@ -1,0 +1,65 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of node-cli
+#
+#   Copyright (C) 2025-Present SKALE Labs
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import json
+from typing import Any, Dict
+
+from node_cli.utils.exit_codes import CLIExitCodes
+from node_cli.utils.helper import error_exit, get_request
+from node_cli.utils.print_formatters import print_chain_record, print_chain_checks
+
+BLUEPRINT_NAME = 'fair-chain'
+
+
+def get_chain_record_plain() -> Dict[str, Any]:
+    status, payload = get_request(blueprint=BLUEPRINT_NAME, method='record')
+    if status == 'ok':
+        if isinstance(payload, dict):
+            return payload.get('record', {})
+        else:
+            error_exit('Invalid response format', exit_code=CLIExitCodes.BAD_API_RESPONSE)
+    else:
+        error_exit(payload, exit_code=CLIExitCodes.BAD_API_RESPONSE)
+
+
+def get_chain_record(raw: bool = False) -> None:
+    record = get_chain_record_plain()
+    if raw:
+        print(json.dumps(record, indent=4))
+    else:
+        print_chain_record(record)
+
+
+def get_chain_checks_plain() -> Dict[str, Any]:
+    status, payload = get_request(blueprint=BLUEPRINT_NAME, method='checks')
+    if status == 'ok':
+        if isinstance(payload, dict):
+            return payload
+        else:
+            error_exit('Invalid response format', exit_code=CLIExitCodes.BAD_API_RESPONSE)
+    else:
+        error_exit(payload, exit_code=CLIExitCodes.BAD_API_RESPONSE)
+
+
+def get_chain_checks(raw: bool = False) -> None:
+    checks = get_chain_checks_plain()
+    if raw:
+        print(json.dumps(checks, indent=4))
+    else:
+        print_chain_checks(checks)

--- a/node_cli/main.py
+++ b/node_cli/main.py
@@ -40,6 +40,7 @@ from node_cli.cli.resources_allocation import resources_allocation_cli
 from node_cli.cli.sync_node import sync_node_cli
 from node_cli.cli.fair_boot import fair_boot_cli
 from node_cli.cli.fair_node import fair_node_cli
+from node_cli.cli.chain import chain_cli
 from node_cli.core.host import init_logs_dir
 from node_cli.utils.node_type import NodeType
 from node_cli.configs import LONG_LINE
@@ -91,6 +92,7 @@ def get_sources_list() -> List[click.MultiCommand]:
             logs_cli,
             fair_boot_cli,
             fair_node_cli,
+            chain_cli,
             wallet_cli,
             ssl_cli,
         ]

--- a/node_cli/utils/print_formatters.py
+++ b/node_cli/utils/print_formatters.py
@@ -325,6 +325,23 @@ def print_meta_info(meta_info: CliMeta) -> None:
     )
 
 
+def format_timestamp(value):
+    if value is None or value == 'N/A' or value == 0 or value == 0.0:
+        return 'N/A'
+    try:
+        timestamp = float(value)
+        if timestamp == 0:
+            return 'N/A'
+        dt = datetime.datetime.fromtimestamp(timestamp)
+        human_date = dt.strftime('%Y-%m-%d %H:%M:%S')
+        return f'{human_date} ({timestamp})'
+    except (ValueError, TypeError):
+        return str(value)
+
+
+1
+
+
 def print_chain_record(record):
     print(
         inspect.cleandoc(f"""
@@ -337,13 +354,13 @@ def print_chain_record(record):
         Backup Run: {record.get('backup_run', 'N/A')}
         Restart Count: {record.get('restart_count', 'N/A')}
         Failed RPC Count: {record.get('failed_rpc_count', 'N/A')}
-        Monitor Last Seen: {record.get('monitor_last_seen', 'N/A')}
-        SSL Change Date: {record.get('ssl_change_date', 'N/A')}
-        Repair Date: {record.get('repair_date', 'N/A')}
+        Monitor Last Seen: {format_timestamp(record.get('monitor_last_seen', 'N/A'))}
+        SSL Change Date: {format_timestamp(record.get('ssl_change_date', 'N/A'))}
+        Repair Date: {format_timestamp(record.get('repair_date', 'N/A'))}
         DKG Status: {record.get('dkg_status', 'N/A')}
-        Repair Timestamp: {record.get('repair_ts', 'N/A')}
+        Repair Timestamp: {format_timestamp(record.get('repair_ts', 'N/A'))}
         Snapshot From: {record.get('snapshot_from', 'N/A')}
-        Restart Timestamp: {record.get('restart_ts', 'N/A')}
+        Restart Timestamp: {format_timestamp(record.get('restart_ts', 'N/A'))}
         Force Skaled Start: {record.get('force_skaled_start', 'N/A')}
         {LONG_LINE}
     """)

--- a/node_cli/utils/print_formatters.py
+++ b/node_cli/utils/print_formatters.py
@@ -323,3 +323,43 @@ def print_meta_info(meta_info: CliMeta) -> None:
         {LONG_LINE}
     """)
     )
+
+
+def print_chain_record(record):
+    print(
+        inspect.cleandoc(f"""
+        {LONG_LINE}
+        Fair Chain Record
+        Chain Name: {record.get('name', 'N/A')}
+        Config Version: {record.get('config_version', 'N/A')}
+        Sync Config Run: {record.get('sync_config_run', 'N/A')}
+        First Run: {record.get('first_run', 'N/A')}
+        Backup Run: {record.get('backup_run', 'N/A')}
+        Restart Count: {record.get('restart_count', 'N/A')}
+        Failed RPC Count: {record.get('failed_rpc_count', 'N/A')}
+        Monitor Last Seen: {record.get('monitor_last_seen', 'N/A')}
+        SSL Change Date: {record.get('ssl_change_date', 'N/A')}
+        Repair Date: {record.get('repair_date', 'N/A')}
+        DKG Status: {record.get('dkg_status', 'N/A')}
+        Repair Timestamp: {record.get('repair_ts', 'N/A')}
+        Snapshot From: {record.get('snapshot_from', 'N/A')}
+        Restart Timestamp: {record.get('restart_ts', 'N/A')}
+        Force Skaled Start: {record.get('force_skaled_start', 'N/A')}
+        {LONG_LINE}
+    """)
+    )
+
+
+def print_chain_checks(checks):
+    def format_checks(check_dict, title):
+        print(f'\n{title}:')
+        for name, result in check_dict.items():
+            status = 'PASS' if result else 'FAIL'
+            print(f'  {name}: {status}')
+
+    print(f'{LONG_LINE}')
+    print('Fair Chain Checks')
+    print(f'{LONG_LINE}')
+    format_checks(checks['config_checks'], 'Config Checks')
+    format_checks(checks['skaled_checks'], 'Skaled Checks')
+    print(f'{LONG_LINE}')

--- a/tests/routes_test.py
+++ b/tests/routes_test.py
@@ -35,6 +35,8 @@ ALL_V1_ROUTES = [
     '/api/v1/fair-node/register',
     '/api/v1/fair-node/change-ip',
     '/api/v1/fair-node/exit',
+    '/api/v1/fair-chain/record',
+    '/api/v1/fair-chain/checks',
 ]
 
 


### PR DESCRIPTION
This pull request adds new functionality for managing and monitoring the Fair chain within the SKALE Node CLI, along with related documentation and minor improvements. The most significant changes are the introduction of new Fair Chain commands, supporting code, and updates to the CLI's routing and formatting logic.

### Fair Chain command additions

* Added `fair chain` CLI group with `record` and `checks` subcommands for retrieving chain record information and performing chain health checks. These commands support JSON output and formatted table views. (`node_cli/cli/chain.py`, `README.md`) [[1]](diffhunk://#diff-50e18fa6ca6b18ec825b7aedf0bd87c11e8d487747b1e62f3dcd2d6e581179b9R1-R44) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R967-R996)
* Implemented backend logic for fetching and displaying Fair chain record and checks, including error handling and output formatting. (`node_cli/fair/chain.py`, `node_cli/utils/print_formatters.py`) [[1]](diffhunk://#diff-65e77c1757898bf5388f6c3f2f6dd960a66711ba7b7708355a412d115adca9bbR1-R65) [[2]](diffhunk://#diff-ffe3da23bcb84c0460a1964069253839e584ece698fc38a372eed99fc8f71fffR326-R365)

### CLI and routing integration

* Registered the new Fair Chain commands in the CLI's main entry point and routing configuration, ensuring they are available to users. (`node_cli/main.py`, `node_cli/configs/routes.py`) [[1]](diffhunk://#diff-51a966fa5f51e476699e712be1c015b0f51df57bb3b6f075fb138cc3a6dac95eR43) [[2]](diffhunk://#diff-51a966fa5f51e476699e712be1c015b0f51df57bb3b6f075fb138cc3a6dac95eR95) [[3]](diffhunk://#diff-12132dde0bdef91d2276291fd892108242ea0254c453d6829b544adc06a76b40R44)

### Documentation updates

* Updated the `README.md` to reflect the new Fair Chain commands, their options, and usage instructions. Also clarified options for the Fair Node update command. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R35) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L844-R845) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L868-R869) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R967-R996)

### Minor improvements

* Fixed a typo in the SSL healthcheck server option help text. (`node_cli/cli/ssl.py`)