### PR TITLE
Add telegraf related env params to fair

### DIFF
--- a/node_cli/cli/fair_boot.py
+++ b/node_cli/cli/fair_boot.py
@@ -50,9 +50,7 @@ def init_boot(env_file):
 
 
 @boot.command('register', help='Register Fair node in SKALE Manager (during Boot Phase).')
-@click.option(
-    '--name', '-n', required=True, prompt='Enter fair node name', help='Fair node name'
-)
+@click.option('--name', '-n', required=True, prompt='Enter fair node name', help='Fair node name')
 @click.option(
     '--ip',
     prompt='Enter node public IP',

--- a/node_cli/configs/user.py
+++ b/node_cli/configs/user.py
@@ -87,7 +87,6 @@ class FairUserConfig(BaseUserConfig):
     sgx_server_url: str
     enforce_btrfs: str = ''
     telegraf: str = ''
-    influx_token: str = ''
     influx_url: str = ''
 
 
@@ -109,7 +108,6 @@ class SkaleUserConfig(BaseUserConfig):
     sgx_server_url: str
     monitoring_containers: str = ''
     telegraf: str = ''
-    influx_token: str = ''
     influx_url: str = ''
     tg_api_key: str = ''
     tg_chat_id: str = ''

--- a/node_cli/configs/user.py
+++ b/node_cli/configs/user.py
@@ -86,6 +86,9 @@ class FairUserConfig(BaseUserConfig):
     boot_endpoint: str
     sgx_server_url: str
     enforce_btrfs: str = ''
+    telegraf: str = ''
+    influx_token: str = ''
+    influx_url: str = ''
 
 
 @dataclass


### PR DESCRIPTION
This pull request introduces additional configuration options to the `FairUserConfig` class in `node_cli/configs/user.py`, providing support for monitoring and metrics collection.

New configuration fields for monitoring:

* Added `telegraf`, `influx_token`, and `influx_url` fields to the `FairUserConfig` class to enable configuration of Telegraf and InfluxDB for monitoring and metrics.