### PR TITLE
Fix fair node tests, fix disk mounting for fair node 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ SKALE Node CLI, part of the SKALE suite of validator tools, is the command line 
    5. [Fair Wallet commands](#fair-wallet-commands)
    6. [Fair Logs commands](#fair-logs-commands)
    7. [Fair SSL commands](#fair-ssl-commands)
+   8. [Passive Fair Node commands](#passive-fair-node-commands)
 5. [Exit codes](#exit-codes)
 6. [Development](#development)
 
@@ -1075,6 +1076,61 @@ Options:
 * `--type`/`-t` - Check type: `all`, `openssl`, or `skaled` (default: `all`).
 * `--no-client` - Skip client connection for openssl check.
 * `--no-wss` - Skip WSS server starting for skaled check.
+
+### Passive Fair Node commands
+
+> Prefix: `fair passive-node` (passive Fair build)
+
+Commands for operating a passive Fair node (sync/indexer/archive).
+
+#### Passive Fair Node Initialization
+
+Initialize a passive Fair node.
+
+```shell
+fair passive-node init <ENV_FILEPATH> --id <NODE_ID> [--indexer | --archive] [--snapshot <URL|any>]
+```
+
+Arguments:
+
+* `ENV_FILEPATH` - Path to the environment file with configuration.
+
+Required environment variables in `ENV_FILEPATH`:
+
+* `FAIR_CONTRACTS` - Fair Manager contracts alias or address.
+* `NODE_VERSION` - Stream of `skale-node` configs.
+* `BOOT_ENDPOINT` - RPC endpoint of Fair network.
+* `DISK_MOUNTPOINT` - Mount point for storing chain data.
+* `ENV_TYPE` - Environment type (e.g., `mainnet`, `devnet`).
+
+Options:
+
+* `--id` - Numerical node identifier (required).
+* `--indexer` - Run in indexer mode (no block rotation).
+* `--archive` - Run in archive mode (historical state kept; disables block rotation). Mutually exclusive with `--indexer`.
+* `--snapshot <URL|any>` - Start from provided snapshot URL or from any available source (not allowed together with `--indexer` or `--archive`).
+
+By default runs a regular sync node.
+
+#### Passive Fair Node Update
+
+Update software / configs for passive Fair node.
+
+```shell
+fair passive-node update <ENV_FILEPATH> [--yes]
+```
+
+#### Passive Fair Node Cleanup
+
+Remove all passive Fair node data and containers.
+
+```shell
+fair passive-node cleanup [--yes]
+```
+
+Options:
+
+* `--yes` - Proceed without confirmation.
 
 ***
 

--- a/node_cli/operations/fair.py
+++ b/node_cli/operations/fair.py
@@ -103,6 +103,8 @@ def init(
     prepare_host(env_filepath, env_type=env['ENV_TYPE'])
     link_env_file()
 
+    prepare_block_device(env['DISK_MOUNTPOINT'], force=env['ENFORCE_BTRFS'] == 'True')
+
     update_images(env=env, node_type=NodeType.FAIR, node_mode=node_mode)
     compose_up(
         env=env, node_type=NodeType.FAIR, node_mode=node_mode, services=list(REDIS_SERVICE_DICT)
@@ -114,7 +116,6 @@ def init(
         if snapshot:
             time.sleep(REDIS_START_TIMEOUT)
             trigger_skaled_snapshot_mode(env=env, snapshot_from=snapshot)
-    prepare_block_device(env['DISK_MOUNTPOINT'], force=env['ENFORCE_BTRFS'] == 'True')
 
     meta_manager = FairCliMetaManager()
     meta_manager.update_meta(

--- a/tests/cli/node_test.py
+++ b/tests/cli/node_test.py
@@ -325,7 +325,6 @@ def test_backup():
     'node_type,node_mode,test_user_conf',
     [
         (NodeType.SKALE, NodeMode.ACTIVE, 'regular_user_conf'),
-        (NodeType.SKALE, NodeMode.PASSIVE, 'passive_user_conf'),
         (NodeType.FAIR, NodeMode.ACTIVE, 'fair_user_conf'),
     ],
 )
@@ -350,7 +349,6 @@ def test_restore(request, node_type, node_mode, test_user_conf, mocked_g_config,
         patch('node_cli.configs.user.validate_alias_or_address'),
     ):
         user_conf_path = request.getfixturevalue(test_user_conf).as_posix()
-
         result = run_command(restore_node, [backup_path, user_conf_path])
         assert result.exit_code == 0
         assert 'Node is restored from backup\n' in result.output  # noqa
@@ -386,7 +384,7 @@ def test_maintenance_off(mocked_g_config):
     )
 
 
-def test_turn_off_maintenance_on(mocked_g_config, regular_user_conf):
+def test_turn_off_maintenance_on(mocked_g_config, regular_user_conf, active_node_option):
     resp_mock = response_mock(requests.codes.ok, {'status': 'ok', 'payload': None})
     with (
         mock.patch('subprocess.run', new=subprocess_run_mock),
@@ -402,6 +400,7 @@ def test_turn_off_maintenance_on(mocked_g_config, regular_user_conf):
             _turn_off,
             ['--maintenance-on', '--yes'],
         )
+
         assert (
             result.output
             == 'Setting maintenance mode on...\nNode is successfully set in maintenance mode\n'
@@ -418,7 +417,7 @@ def test_turn_off_maintenance_on(mocked_g_config, regular_user_conf):
             assert result.exit_code == CLIExitCodes.UNSAFE_UPDATE
 
 
-def test_turn_on_maintenance_off(mocked_g_config, regular_user_conf):
+def test_turn_on_maintenance_off(mocked_g_config, regular_user_conf, active_node_option):
     resp_mock = response_mock(requests.codes.ok, {'status': 'ok', 'payload': None})
     with (
         mock.patch('subprocess.run', new=subprocess_run_mock),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,7 +121,10 @@ def resource_alloc():
     with open(RESOURCE_ALLOCATION_FILEPATH, 'w') as alloc_file:
         json.dump({}, alloc_file)
     yield RESOURCE_ALLOCATION_FILEPATH
-    os.remove(RESOURCE_ALLOCATION_FILEPATH)
+    try:
+        os.remove(RESOURCE_ALLOCATION_FILEPATH)
+    except FileNotFoundError:
+        pass
 
 
 @pytest.fixture
@@ -132,7 +135,10 @@ def inited_node():
     try:
         yield
     finally:
-        os.remove(NGINX_CONFIG_FILEPATH)
+        try:
+            os.remove(NGINX_CONFIG_FILEPATH)
+        except FileNotFoundError:
+            pass
 
 
 @pytest.fixture
@@ -158,7 +164,13 @@ def active_node_option():
     try:
         yield
     finally:
-        shutil.rmtree(NODE_OPTIONS_FILEPATH)
+        try:
+            if os.path.isdir(NODE_OPTIONS_FILEPATH):
+                shutil.rmtree(NODE_OPTIONS_FILEPATH)
+            elif os.path.isfile(NODE_OPTIONS_FILEPATH):
+                os.remove(NODE_OPTIONS_FILEPATH)
+        except FileNotFoundError:
+            pass
 
 
 @pytest.fixture
@@ -226,7 +238,10 @@ def meta_file_v3():
     try:
         yield META_FILEPATH
     finally:
-        os.remove(META_FILEPATH)
+        try:
+            os.remove(META_FILEPATH)
+        except FileNotFoundError:
+            pass
 
 
 @pytest.fixture

--- a/tests/fair/fair_node_test.py
+++ b/tests/fair/fair_node_test.py
@@ -223,6 +223,7 @@ def test_cleanup_continues_after_fair_op_error(
     inited_node,
     resource_alloc,
     meta_file_v3,
+    active_node_option,
 ):
     mock_env = {'ENV_TYPE': 'devnet'}
     mock_compose_env.return_value = mock_env

--- a/tests/fair/fair_node_test.py
+++ b/tests/fair/fair_node_test.py
@@ -23,6 +23,7 @@ def test_restore_fair(
     mock_sleep,
     valid_env_file,
     ensure_meta_removed,
+    active_node_option,
 ):
     mock_env = {'ENV_TYPE': 'devnet'}
     mock_compose_env.return_value = mock_env
@@ -31,11 +32,16 @@ def test_restore_fair(
 
     restore(backup_path, valid_env_file)
 
-    mock_compose_env.assert_called_once_with(valid_env_file, node_type=NodeType.FAIR)
+    mock_compose_env.assert_called_once_with(
+        valid_env_file, node_type=NodeType.FAIR, node_mode=NodeMode.ACTIVE
+    )
     mock_save_env.assert_called_once_with(valid_env_file)
     expected_env = {**mock_env, 'SKALE_DIR': SKALE_DIR}
     mock_restore_op.assert_called_once_with(
-        NodeMode.ACTIVE, expected_env, backup_path, config_only=False
+        node_mode=NodeMode.ACTIVE,
+        env=expected_env,
+        backup_path=backup_path,
+        config_only=False,
     )
     mock_sleep.assert_called_once()
 
@@ -60,6 +66,7 @@ def test_init_fair_boot(
     mock_compose_env.assert_called_once_with(
         valid_env_file,
         node_type=NodeType.FAIR,
+        node_mode=NodeMode.ACTIVE,
         is_fair_boot=True,
     )
     mock_init_op.assert_called_once_with(valid_env_file, mock_env)
@@ -96,6 +103,7 @@ def test_update_fair_boot(
         sync_schains=False,
         pull_config_for_schain=pull_config_for_schain,
         node_type=NodeType.FAIR,
+        node_mode=NodeMode.ACTIVE,
         is_fair_boot=True,
     )
     mock_update_op.assert_called_once_with(valid_env_file, mock_env)
@@ -126,6 +134,7 @@ def test_migrate_from_boot(
         inited_node=True,
         sync_schains=False,
         node_type=NodeType.FAIR,
+        node_mode=NodeMode.ACTIVE,
     )
     mock_migrate_op.assert_called_once_with(
         valid_env_file, mock_env, update_type=FairUpdateType.FROM_BOOT, force_skaled_start=False

--- a/tests/fair/fair_node_test.py
+++ b/tests/fair/fair_node_test.py
@@ -71,7 +71,9 @@ def test_init_fair_boot(
     )
     mock_init_op.assert_called_once_with(valid_env_file, mock_env)
     mock_sleep.assert_called_once()
-    mock_is_alive.assert_called_once_with(node_type=NodeType.FAIR, is_fair_boot=True)
+    mock_is_alive.assert_called_once_with(
+        node_type=NodeType.FAIR, node_mode=NodeMode.ACTIVE, is_fair_boot=True
+    )
 
 
 @mock.patch('node_cli.utils.decorators.is_user_valid', return_value=True)
@@ -108,7 +110,9 @@ def test_update_fair_boot(
     )
     mock_update_op.assert_called_once_with(valid_env_file, mock_env)
     mock_sleep.assert_called_once()
-    mock_is_alive.assert_called_once_with(node_type=NodeType.FAIR, is_fair_boot=True)
+    mock_is_alive.assert_called_once_with(
+        node_type=NodeType.FAIR, node_mode=NodeMode.ACTIVE, is_fair_boot=True
+    )
 
 
 @mock.patch('node_cli.fair.active.update_fair_op')
@@ -137,7 +141,11 @@ def test_migrate_from_boot(
         node_mode=NodeMode.ACTIVE,
     )
     mock_migrate_op.assert_called_once_with(
-        valid_env_file, mock_env, update_type=FairUpdateType.FROM_BOOT, force_skaled_start=False
+        valid_env_file,
+        mock_env,
+        node_mode=NodeMode.ACTIVE,
+        update_type=FairUpdateType.FROM_BOOT,
+        force_skaled_start=False,
     )
 
 

--- a/tests/fair/fair_node_test.py
+++ b/tests/fair/fair_node_test.py
@@ -151,9 +151,12 @@ def test_cleanup_success(
     cleanup()
 
     mock_compose_env.assert_called_once_with(
-        SKALE_DIR_ENV_FILEPATH, save=False, node_type=NodeType.FAIR
+        SKALE_DIR_ENV_FILEPATH,
+        save=False,
+        node_type=NodeType.FAIR,
+        node_mode=NodeMode.ACTIVE,
     )
-    mock_cleanup_fair_op.assert_called_once_with(mock_env)
+    mock_cleanup_fair_op.assert_called_once_with(node_mode=NodeMode.ACTIVE, env=mock_env)
     mock_cleanup_docker_config.assert_called_once()
 
 
@@ -184,8 +187,8 @@ def test_cleanup_calls_operations_in_correct_order(
     cleanup()
 
     expected_calls = [
-        mock.call.compose_env(mock.ANY, save=False, node_type=mock.ANY),
-        mock.call.cleanup_fair_op(mock_env),
+        mock.call.compose_env(mock.ANY, save=False, node_type=mock.ANY, node_mode=NodeMode.ACTIVE),
+        mock.call.cleanup_fair_op(node_mode=NodeMode.ACTIVE, env=mock_env),
         mock.call.cleanup_docker_config(),
     ]
     manager.assert_has_calls(expected_calls, any_order=False)
@@ -211,7 +214,7 @@ def test_cleanup_continues_after_fair_op_error(
         cleanup()
 
     mock_compose_env.assert_called_once()
-    mock_cleanup_fair_op.assert_called_once_with(mock_env)
+    mock_cleanup_fair_op.assert_called_once_with(node_mode=NodeMode.ACTIVE, env=mock_env)
     mock_cleanup_docker_config.assert_not_called()
 
 


### PR DESCRIPTION
This pull request introduces a new set of commands for managing passive Fair nodes and improves test reliability and consistency across the codebase. The most significant changes are the addition of passive Fair node documentation and commands, improvements to test cleanup logic, and updates to ensure consistent handling of node modes in Fair node operations and tests.

**Passive Fair Node CLI and Documentation:**

* Added documentation and CLI commands for managing passive Fair nodes (`sync`, `indexer`, `archive` modes), including initialization, update, and cleanup commands in the `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R35) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1080-R1134)

**Test Improvements and Reliability:**

* Enhanced test fixtures in `tests/conftest.py` to handle file and directory cleanup more robustly, preventing errors if files do not exist. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R124-R127) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R138-R141) [[3]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R167-R173) [[4]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R241-R244)
* Updated Fair node tests in `tests/fair/fair_node_test.py` to explicitly pass and check the `node_mode` parameter (now always `NodeMode.ACTIVE`), ensuring consistency and correctness in test calls and expectations. [[1]](diffhunk://#diff-c1acfffdf1599fb92312e433c15b9cb9d54baaa589b0d7fc28e2c0eefb1285c5R26) [[2]](diffhunk://#diff-c1acfffdf1599fb92312e433c15b9cb9d54baaa589b0d7fc28e2c0eefb1285c5L34-R44) [[3]](diffhunk://#diff-c1acfffdf1599fb92312e433c15b9cb9d54baaa589b0d7fc28e2c0eefb1285c5R69) [[4]](diffhunk://#diff-c1acfffdf1599fb92312e433c15b9cb9d54baaa589b0d7fc28e2c0eefb1285c5R106) [[5]](diffhunk://#diff-c1acfffdf1599fb92312e433c15b9cb9d54baaa589b0d7fc28e2c0eefb1285c5R137) [[6]](diffhunk://#diff-c1acfffdf1599fb92312e433c15b9cb9d54baaa589b0d7fc28e2c0eefb1285c5L154-R168) [[7]](diffhunk://#diff-c1acfffdf1599fb92312e433c15b9cb9d54baaa589b0d7fc28e2c0eefb1285c5L187-R200) [[8]](diffhunk://#diff-c1acfffdf1599fb92312e433c15b9cb9d54baaa589b0d7fc28e2c0eefb1285c5L214-R226)

**Fair Node Operation Logic:**

* Moved the `prepare_block_device` call in `node_cli/operations/fair.py` to ensure correct device preparation order during passive node initialization. [[1]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cR106-R107) [[2]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cL117)

**Test Parameter Adjustments:**

* Updated test signatures and parameters in `tests/cli/node_test.py` for maintenance mode tests to use the `active_node_option` fixture, improving test setup. [[1]](diffhunk://#diff-7f52d18f7b9164c2c4fa77e3d684dc5ec69a5dd967f950d7d5fd6046bb612b81L389-R387) [[2]](diffhunk://#diff-7f52d18f7b9164c2c4fa77e3d684dc5ec69a5dd967f950d7d5fd6046bb612b81L421-R420)
* Removed the passive SKALE node backup test parameter, focusing backup tests on supported node types.

These changes collectively enhance the CLI's usability for passive Fair nodes, improve test reliability, and ensure correct operation and testing of Fair node commands.