### PR TITLE
Skip host requirements for fair passive nodes, update tests

### DIFF
--- a/node_cli/cli/fair_node.py
+++ b/node_cli/cli/fair_node.py
@@ -22,7 +22,7 @@ import click
 from node_cli.core.node import backup
 
 from node_cli.fair.active import change_ip as change_ip_fair
-from node_cli.fair.common import cleanup as fair_cleanup
+from node_cli.fair.common import cleanup as cleanup_fair
 from node_cli.fair.active import exit as exit_fair
 from node_cli.fair.active import (
     get_node_info,
@@ -164,7 +164,7 @@ def repair(snapshot_from: str = 'any') -> None:
 )
 @streamed_cmd
 def cleanup_node():
-    fair_cleanup()
+    cleanup_fair(node_mode=NodeMode.ACTIVE)
 
 
 @node.command('change-ip', help=TEXTS['fair']['node']['change-ip']['help'])

--- a/node_cli/cli/passive_fair_node.py
+++ b/node_cli/cli/passive_fair_node.py
@@ -112,7 +112,7 @@ def update_node(env_filepath: str, pull_config_for_schain, force_skaled_start: b
 )
 @streamed_cmd
 def cleanup_node():
-    cleanup_fair()
+    cleanup_fair(node_mode=NodeMode.PASSIVE)
 
 
 @passive_node.command('setup', help=TEXTS['fair']['node']['setup']['help'])

--- a/node_cli/core/checks.py
+++ b/node_cli/core/checks.py
@@ -56,10 +56,12 @@ from node_cli.configs import (
     REPORTS_PATH,
 )
 from node_cli.core.host import is_ufw_ipv6_chain_exists, is_ufw_ipv6_option_enabled
+from node_cli.core.node_options import upsert_node_mode
 from node_cli.core.resources import get_disk_size
 from node_cli.core.static_config import get_static_params
 from node_cli.utils.docker_utils import NodeType
 from node_cli.utils.helper import run_cmd, safe_mkdir
+from node_cli.utils.node_type import NodeMode
 
 logger = logging.getLogger(__name__)
 
@@ -272,7 +274,7 @@ class PackageChecker(BaseChecker):
     def __init__(self, requirements: Dict) -> None:
         super().__init__(requirements=requirements)
 
-    def _check_apt_package(self, package_name: str, version: str = None) -> CheckResult:
+    def _check_apt_package(self, package_name: str, version: str | None = None) -> CheckResult:
         # TODO: check versions
         dpkg_cmd_result = run_cmd(['dpkg', '-s', package_name], check_code=False)
         output = dpkg_cmd_result.stdout.decode('utf-8').strip()
@@ -457,12 +459,14 @@ def get_checks(checkers: List[BaseChecker], check_type: CheckType = CheckType.AL
     )
 
 
-def get_all_checkers(disk: str, requirements: Dict) -> List[BaseChecker]:
-    return [
-        MachineChecker(requirements['server'], disk),
+def get_all_checkers(disk: str, requirements: Dict, node_mode: NodeMode) -> List[BaseChecker]:
+    checkers = [
         PackageChecker(requirements['package']),
         DockerChecker(requirements['docker']),
     ]
+    if node_mode == NodeMode.ACTIVE:
+        checkers.append(MachineChecker(requirements['server'], disk))
+    return checkers
 
 
 def run_checks(
@@ -474,7 +478,9 @@ def run_checks(
 ) -> ResultList:
     logger.info('Executing checks. Type: %s', check_type)
     requirements = get_static_params(node_type, env_type, config_path)
-    checkers = get_all_checkers(disk, requirements)
+    node_mode = upsert_node_mode()
+
+    checkers = get_all_checkers(disk, requirements, node_mode)
     checks = get_checks(checkers, check_type)
     results = [check() for check in checks]
 

--- a/node_cli/fair/common.py
+++ b/node_cli/fair/common.py
@@ -79,8 +79,8 @@ def init(
 
 
 @check_user
-def cleanup() -> None:
-    node_mode = upsert_node_mode()
+def cleanup(node_mode: NodeMode) -> None:
+    node_mode = upsert_node_mode(node_mode=node_mode)
     env = compose_node_env(
         SKALE_DIR_ENV_FILEPATH, save=False, node_type=NodeType.FAIR, node_mode=node_mode
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,7 +184,13 @@ def passive_node_option():
     try:
         yield
     finally:
-        shutil.rmtree(NODE_OPTIONS_FILEPATH)
+        try:
+            if os.path.isdir(NODE_OPTIONS_FILEPATH):
+                shutil.rmtree(NODE_OPTIONS_FILEPATH)
+            elif os.path.isfile(NODE_OPTIONS_FILEPATH):
+                os.remove(NODE_OPTIONS_FILEPATH)
+        except FileNotFoundError:
+            pass
 
 
 @pytest.fixture

--- a/tests/core/core_checks_test.py
+++ b/tests/core/core_checks_test.py
@@ -322,9 +322,9 @@ def test_get_all_checkers(requirements_data, active_node_option):
     disk = 'test-disk'
     checkers = get_all_checkers(disk, requirements_data, node_mode=NodeMode.ACTIVE)
     assert len(checkers) == 3
-    assert isinstance(checkers[0], MachineChecker)
-    assert isinstance(checkers[1], PackageChecker)
-    assert isinstance(checkers[2], DockerChecker)
+    assert isinstance(checkers[0], PackageChecker)
+    assert isinstance(checkers[1], DockerChecker)
+    assert isinstance(checkers[2], MachineChecker)
 
 
 def test_get_checks(requirements_data, active_node_option):

--- a/tests/core/core_checks_test.py
+++ b/tests/core/core_checks_test.py
@@ -327,6 +327,14 @@ def test_get_all_checkers(requirements_data, active_node_option):
     assert isinstance(checkers[2], MachineChecker)
 
 
+def test_get_all_checkers_passive(requirements_data, passive_node_option):
+    disk = 'test-disk'
+    checkers = get_all_checkers(disk, requirements_data, node_mode=NodeMode.PASSIVE)
+    assert len(checkers) == 2
+    assert isinstance(checkers[0], PackageChecker)
+    assert isinstance(checkers[1], DockerChecker)
+
+
 def test_get_checks(requirements_data, active_node_option):
     disk = 'test-disk'
     checkers = get_all_checkers(disk, requirements_data, node_mode=NodeMode.ACTIVE)

--- a/tests/core/core_checks_test.py
+++ b/tests/core/core_checks_test.py
@@ -21,7 +21,7 @@ from node_cli.core.checks import (
     save_report,
 )
 
-from node_cli.utils.node_type import NodeType
+from node_cli.utils.node_type import NodeMode, NodeType
 
 
 @pytest.fixture
@@ -318,18 +318,18 @@ def test_checks_apt_package(package_req):
         assert r.status == 'ok'
 
 
-def test_get_all_checkers(requirements_data):
+def test_get_all_checkers(requirements_data, active_node_option):
     disk = 'test-disk'
-    checkers = get_all_checkers(disk, requirements_data)
+    checkers = get_all_checkers(disk, requirements_data, node_mode=NodeMode.ACTIVE)
     assert len(checkers) == 3
     assert isinstance(checkers[0], MachineChecker)
     assert isinstance(checkers[1], PackageChecker)
     assert isinstance(checkers[2], DockerChecker)
 
 
-def test_get_checks(requirements_data):
+def test_get_checks(requirements_data, active_node_option):
     disk = 'test-disk'
-    checkers = get_all_checkers(disk, requirements_data)
+    checkers = get_all_checkers(disk, requirements_data, node_mode=NodeMode.ACTIVE)
     checks = get_checks(checkers)
     assert len(checks) == 16
     checks = get_checks(checkers, check_type=CheckType.PREINSTALL)
@@ -338,9 +338,9 @@ def test_get_checks(requirements_data):
     assert len(checks) == 2
 
 
-def test_get_checks_fair(fair_requirements_data):
+def test_get_checks_fair(fair_requirements_data, active_node_option):
     disk = 'test-disk'
-    fair_checkers = get_all_checkers(disk, fair_requirements_data)
+    fair_checkers = get_all_checkers(disk, fair_requirements_data, node_mode=NodeMode.ACTIVE)
 
     fair_all_checks = get_checks(fair_checkers, CheckType.ALL)
     fair_all_names = {f.func.__name__ for f in fair_all_checks}

--- a/tests/fair/fair_node_test.py
+++ b/tests/fair/fair_node_test.py
@@ -161,11 +161,12 @@ def test_cleanup_success(
     inited_node,
     resource_alloc,
     meta_file_v3,
+    active_node_option,
 ):
     mock_env = {'ENV_TYPE': 'devnet'}
     mock_compose_env.return_value = mock_env
 
-    cleanup()
+    cleanup(node_mode=NodeMode.ACTIVE)
 
     mock_compose_env.assert_called_once_with(
         SKALE_DIR_ENV_FILEPATH,
@@ -201,7 +202,7 @@ def test_cleanup_calls_operations_in_correct_order(
     manager.attach_mock(mock_cleanup_fair_op, 'cleanup_fair_op')
     manager.attach_mock(mock_cleanup_docker_config, 'cleanup_docker_config')
 
-    cleanup()
+    cleanup(node_mode=NodeMode.ACTIVE)
 
     expected_calls = [
         mock.call.compose_env(mock.ANY, save=False, node_type=mock.ANY, node_mode=NodeMode.ACTIVE),
@@ -229,7 +230,7 @@ def test_cleanup_continues_after_fair_op_error(
     mock_compose_env.return_value = mock_env
 
     with pytest.raises(Exception, match='Cleanup failed'):
-        cleanup()
+        cleanup(node_mode=NodeMode.ACTIVE)
 
     mock_compose_env.assert_called_once()
     mock_cleanup_fair_op.assert_called_once_with(node_mode=NodeMode.ACTIVE, env=mock_env)
@@ -249,14 +250,14 @@ def test_cleanup_fails_when_user_invalid(
     from node_cli.fair.common import cleanup
 
     with pytest.raises(SystemExit):
-        cleanup()
+        cleanup(node_mode=NodeMode.ACTIVE)
 
 
 def test_cleanup_fails_when_not_inited(ensure_meta_removed, active_node_option):
     import pytest
 
     with pytest.raises(SystemExit):
-        cleanup()
+        cleanup(node_mode=NodeMode.ACTIVE)
 
 
 @mock.patch('node_cli.utils.decorators.is_user_valid', return_value=True)
@@ -278,7 +279,7 @@ def test_cleanup_logs_success_message(
     mock_env = {'ENV_TYPE': 'devnet'}
     mock_compose_env.return_value = mock_env
 
-    cleanup()
+    cleanup(node_mode=NodeMode.ACTIVE)
 
     mock_logger.info.assert_called_once_with(
         'Fair node was cleaned up, all containers and data removed'


### PR DESCRIPTION
This pull request refactors the cleanup and node check logic to make node mode (active or passive) explicit in function calls, and updates related tests and function signatures accordingly. The changes improve clarity and correctness when performing cleanup and system checks for different node modes.

**Refactoring cleanup logic and function signatures:**

* The `cleanup` function in `node_cli/fair/common.py` now requires a `node_mode` argument, making the node mode explicit and removing reliance on internal detection. All calls to `cleanup` in CLI commands and tests have been updated to pass the appropriate `NodeMode` value. [[1]](diffhunk://#diff-a6b253ee2676f6f2dd5f85aebe05e0504677f9052dee3bde3fca3890d78fa531L82-R83) [[2]](diffhunk://#diff-2f82f30c374ab8a51e09163549a12b05544deb7793f40e09c028aa2457d91364L25-R25) [[3]](diffhunk://#diff-2f82f30c374ab8a51e09163549a12b05544deb7793f40e09c028aa2457d91364L167-R167) [[4]](diffhunk://#diff-4c709cc566179479c162f75ac17db239204e4366e95e49237797e1c3096bf25dL115-R115) [[5]](diffhunk://#diff-c1acfffdf1599fb92312e433c15b9cb9d54baaa589b0d7fc28e2c0eefb1285c5R164-R169) [[6]](diffhunk://#diff-c1acfffdf1599fb92312e433c15b9cb9d54baaa589b0d7fc28e2c0eefb1285c5L204-R205) [[7]](diffhunk://#diff-c1acfffdf1599fb92312e433c15b9cb9d54baaa589b0d7fc28e2c0eefb1285c5L232-R233) [[8]](diffhunk://#diff-c1acfffdf1599fb92312e433c15b9cb9d54baaa589b0d7fc28e2c0eefb1285c5L252-R260) [[9]](diffhunk://#diff-c1acfffdf1599fb92312e433c15b9cb9d54baaa589b0d7fc28e2c0eefb1285c5L281-R282)

**System check improvements:**

* The `get_all_checkers` function in `node_cli/core/checks.py` now takes a `node_mode` parameter and returns a different set of checkers based on the mode: `MachineChecker` is only included for active nodes. The function signature and its usage in `run_checks` and tests have been updated accordingly. [[1]](diffhunk://#diff-175ee3f811ad07c7e3e107c10872f40cef842717973e85ea05982d09408d45c0L460-R469) [[2]](diffhunk://#diff-175ee3f811ad07c7e3e107c10872f40cef842717973e85ea05982d09408d45c0L477-R483) [[3]](diffhunk://#diff-5604d2b3aae8169db564d4c89f8164692a5ecb01fa57e998a177694a556c8124L321-R340) [[4]](diffhunk://#diff-5604d2b3aae8169db564d4c89f8164692a5ecb01fa57e998a177694a556c8124L341-R351)
* The `get_all_checkers` and related test assertions have been updated to reflect the new order and count of checkers depending on node mode.

**Type and import updates:**

* Type annotations have been modernized, using `str | None` instead of `Optional[str]` in `_check_apt_package`.
* Additional imports for `NodeMode` and related helpers have been added where necessary. [[1]](diffhunk://#diff-175ee3f811ad07c7e3e107c10872f40cef842717973e85ea05982d09408d45c0R59-R64) [[2]](diffhunk://#diff-5604d2b3aae8169db564d4c89f8164692a5ecb01fa57e998a177694a556c8124L24-R24)

**Test cleanup improvements:**

* The test fixture for cleaning up node options in `tests/conftest.py` now handles both file and directory cases, preventing errors if the path exists as either.