### PR TITLE
Add node mode to checked host

### DIFF
--- a/node_cli/core/checks.py
+++ b/node_cli/core/checks.py
@@ -56,7 +56,6 @@ from node_cli.configs import (
     REPORTS_PATH,
 )
 from node_cli.core.host import is_ufw_ipv6_chain_exists, is_ufw_ipv6_option_enabled
-from node_cli.core.node_options import upsert_node_mode
 from node_cli.core.resources import get_disk_size
 from node_cli.core.static_config import get_static_params
 from node_cli.utils.docker_utils import NodeType

--- a/node_cli/core/checks.py
+++ b/node_cli/core/checks.py
@@ -472,13 +472,13 @@ def get_all_checkers(disk: str, requirements: Dict, node_mode: NodeMode) -> List
 def run_checks(
     disk: str,
     node_type: NodeType,
+    node_mode: NodeMode,
     env_type: str = 'mainnet',
     config_path: str = CONTAINER_CONFIG_PATH,
     check_type: CheckType = CheckType.ALL,
 ) -> ResultList:
     logger.info('Executing checks. Type: %s', check_type)
     requirements = get_static_params(node_type, env_type, config_path)
-    node_mode = upsert_node_mode()
 
     checkers = get_all_checkers(disk, requirements, node_mode)
     checks = get_checks(checkers, check_type)

--- a/node_cli/core/node.py
+++ b/node_cli/core/node.py
@@ -541,7 +541,7 @@ def run_checks(
     if disk is None:
         env_config = get_validated_user_config(node_type=node_type, node_mode=node_mode)
         disk = env_config.disk_mountpoint
-    failed_checks = run_host_checks(disk, node_type, network, container_config_path)
+    failed_checks = run_host_checks(disk, node_type, node_mode, network, container_config_path)
     if not failed_checks:
         print('Requirements checking successfully finished!')
     else:

--- a/node_cli/fair/boot.py
+++ b/node_cli/fair/boot.py
@@ -67,7 +67,7 @@ def update(env_filepath: str, pull_config_for_schain: str) -> None:
         node_mode=node_mode,
         is_fair_boot=True,
     )
-    migrate_ok = update_fair_boot_op(env_filepath, env)
+    migrate_ok = update_fair_boot_op(env_filepath, env, node_mode=NodeMode.ACTIVE)
     if migrate_ok:
         logger.info('Waiting for containers initialization')
         time.sleep(TM_INIT_TIMEOUT)

--- a/node_cli/fair/boot.py
+++ b/node_cli/fair/boot.py
@@ -45,7 +45,7 @@ def init(env_filepath: str) -> None:
         is_fair_boot=True,
     )
 
-    init_fair_boot_op(env_filepath, env)
+    init_fair_boot_op(env_filepath, env, node_mode)
     logger.info('Waiting for fair containers initialization')
     time.sleep(TM_INIT_TIMEOUT)
     if not is_base_containers_alive(node_type=node_type, node_mode=node_mode, is_fair_boot=True):

--- a/node_cli/operations/base.py
+++ b/node_cli/operations/base.py
@@ -79,11 +79,12 @@ logger = logging.getLogger(__name__)
 
 def checked_host(func):
     @functools.wraps(func)
-    def wrapper(env_filepath: str, env: Dict, *args, **kwargs):
+    def wrapper(env_filepath: str, env: Dict, node_mode: NodeMode, *args, **kwargs):
         download_skale_node(env.get('NODE_VERSION'), env.get('CONTAINER_CONFIGS_DIR'))
         failed_checks = run_host_checks(
             env['DISK_MOUNTPOINT'],
             TYPE,
+            node_mode,
             env['ENV_TYPE'],
             CONTAINER_CONFIG_TMP_PATH,
             check_type=CheckType.PREINSTALL,
@@ -99,6 +100,7 @@ def checked_host(func):
         failed_checks = run_host_checks(
             env['DISK_MOUNTPOINT'],
             TYPE,
+            node_mode,
             env['ENV_TYPE'],
             CONTAINER_CONFIG_PATH,
             check_type=CheckType.POSTINSTALL,
@@ -155,8 +157,8 @@ def update(env_filepath: str, env: Dict, node_type: NodeType, node_mode: NodeMod
 
 
 @checked_host
-def update_fair_boot(env_filepath: str, env: Dict) -> bool:
-    compose_rm(node_type=NodeType.FAIR, node_mode=NodeMode.ACTIVE, env=env)
+def update_fair_boot(env_filepath: str, env: Dict, node_mode: NodeMode = NodeMode.ACTIVE) -> bool:
+    compose_rm(node_type=NodeType.FAIR, node_mode=node_mode, env=env)
     remove_dynamic_containers()
     cleanup_volume_artifacts(env['DISK_MOUNTPOINT'])
 
@@ -233,7 +235,7 @@ def init(env_filepath: str, env: dict, node_type: NodeType, node_mode: NodeMode)
 
 
 @checked_host
-def init_fair_boot(env_filepath: str, env: dict) -> None:
+def init_fair_boot(env_filepath: str, env: dict, node_mode: NodeMode = NodeMode.ACTIVE) -> None:
     sync_skale_node()
     cleanup_volume_artifacts(env['DISK_MOUNTPOINT'])
 
@@ -381,6 +383,7 @@ def restore(env, backup_path, node_type: NodeType, config_only=False):
     failed_checks = run_host_checks(
         env['DISK_MOUNTPOINT'],
         TYPE,
+        node_mode,
         env['ENV_TYPE'],
         CONTAINER_CONFIG_PATH,
         check_type=CheckType.PREINSTALL,
@@ -415,6 +418,7 @@ def restore(env, backup_path, node_type: NodeType, config_only=False):
     failed_checks = run_host_checks(
         env['DISK_MOUNTPOINT'],
         TYPE,
+        node_mode,
         env['ENV_TYPE'],
         CONTAINER_CONFIG_PATH,
         check_type=CheckType.POSTINSTALL,

--- a/node_cli/operations/base.py
+++ b/node_cli/operations/base.py
@@ -93,7 +93,7 @@ def checked_host(func):
             print_failed_requirements_checks(failed_checks)
             return False
 
-        result = func(env_filepath, env, *args, **kwargs)
+        result = func(env_filepath, env, node_mode, *args, **kwargs)
         if not result:
             return result
 

--- a/node_cli/operations/fair.py
+++ b/node_cli/operations/fair.py
@@ -132,8 +132,8 @@ def init(
 
 
 @checked_host
-def update_fair_boot(env_filepath: str, env: dict) -> bool:
-    compose_rm(node_type=NodeType.FAIR, node_mode=NodeMode.ACTIVE, env=env)
+def update_fair_boot(env_filepath: str, env: dict, node_mode: NodeMode = NodeMode.ACTIVE) -> bool:
+    compose_rm(node_type=NodeType.FAIR, node_mode=node_mode, env=env)
     remove_dynamic_containers()
     cleanup_volume_artifacts(env['DISK_MOUNTPOINT'])
 
@@ -236,6 +236,7 @@ def restore(node_mode: NodeMode, env, backup_path, config_only=False):
     failed_checks = run_host_checks(
         env['DISK_MOUNTPOINT'],
         TYPE,
+        node_mode,
         env['ENV_TYPE'],
         CONTAINER_CONFIG_PATH,
         check_type=CheckType.PREINSTALL,
@@ -268,6 +269,7 @@ def restore(node_mode: NodeMode, env, backup_path, config_only=False):
     failed_checks = run_host_checks(
         env['DISK_MOUNTPOINT'],
         TYPE,
+        node_mode,
         env['ENV_TYPE'],
         CONTAINER_CONFIG_PATH,
         check_type=CheckType.POSTINSTALL,

--- a/tests/fair/fair_node_test.py
+++ b/tests/fair/fair_node_test.py
@@ -69,7 +69,11 @@ def test_init_fair_boot(
         node_mode=NodeMode.ACTIVE,
         is_fair_boot=True,
     )
-    mock_init_op.assert_called_once_with(valid_env_file, mock_env)
+    mock_init_op.assert_called_once_with(
+        valid_env_file,
+        mock_env,
+        NodeMode.ACTIVE,
+    )
     mock_sleep.assert_called_once()
     mock_is_alive.assert_called_once_with(
         node_type=NodeType.FAIR, node_mode=NodeMode.ACTIVE, is_fair_boot=True
@@ -108,7 +112,11 @@ def test_update_fair_boot(
         node_mode=NodeMode.ACTIVE,
         is_fair_boot=True,
     )
-    mock_update_op.assert_called_once_with(valid_env_file, mock_env)
+    mock_update_op.assert_called_once_with(
+        valid_env_file,
+        mock_env,
+        node_mode=NodeMode.ACTIVE,
+    )
     mock_sleep.assert_called_once()
     mock_is_alive.assert_called_once_with(
         node_type=NodeType.FAIR, node_mode=NodeMode.ACTIVE, is_fair_boot=True


### PR DESCRIPTION
This pull request refactors how the `node_mode` parameter is handled throughout the codebase, ensuring that it is explicitly passed to functions that require it, rather than being inferred or set internally. This change improves code clarity and reduces hidden dependencies, especially in host checking and node operation workflows.

**Refactoring: Explicitly pass `node_mode`**

* The `run_host_checks` and related functions now require `node_mode` to be passed explicitly, rather than being set internally or defaulted, making the function signatures clearer and reducing implicit dependencies. [[1]](diffhunk://#diff-175ee3f811ad07c7e3e107c10872f40cef842717973e85ea05982d09408d45c0R474-L481) [[2]](diffhunk://#diff-cd8b3a0d0a5921ad426729c3dbcd0ae7a148dd6772be2cc807da4316dd166050L544-R544) [[3]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L82-R87) [[4]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653R103) [[5]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cR239) [[6]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cR272) [[7]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653R386) [[8]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653R421)

**Function signature updates**

* The `checked_host` decorator and all decorated functions (such as `update_fair_boot` and `init_fair_boot` in both `base.py` and `fair.py`) have updated signatures to accept `node_mode` as a parameter, with sensible defaults where appropriate. [[1]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L158-R161) [[2]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L236-R238) [[3]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cL135-R136)

**Code cleanup**

* Removed the unused import of `upsert_node_mode` from `node_options`, as `node_mode` is now always passed explicitly.