### PR TITLE
Add 311 port to ServicePorts

### DIFF
--- a/node_cli/core/nftables.py
+++ b/node_cli/core/nftables.py
@@ -22,9 +22,9 @@ import logging
 import os
 import shutil
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
-from dataclasses import dataclass
 
 from node_cli.configs import (
     ENV,
@@ -44,7 +44,8 @@ class ServicePort:
     DNS: int = 53
     CADVISOR: int = 9100
     EXPORTER: int = 8080
-    WATCHDOG: int = 3009
+    WATCHDOG_HTTP: int = 3009
+    WATCHDOG_HTTPS: int = 311
     HTTPS: int = 443
     HTTP: int = 80
 
@@ -561,7 +562,8 @@ class NFTablesManager:
                 ServicePort.DNS,
                 ServicePort.HTTPS,
                 ServicePort.HTTP,
-                ServicePort.WATCHDOG,
+                ServicePort.WATCHDOG_HTTP,
+                ServicePort.WATCHDOG_HTTPS,
             ]
             if enable_monitoring:
                 tcp_ports.extend([ServicePort.EXPORTER, ServicePort.CADVISOR])
@@ -601,7 +603,8 @@ class NFTablesManager:
         self.remove_drop_rule('udp')
         tcp_ports = [
             ServicePort.HTTPS,
-            ServicePort.WATCHDOG,
+            ServicePort.WATCHDOG_HTTP,
+            ServicePort.WATCHDOG_HTTPS,
             ServicePort.EXPORTER,
             ServicePort.CADVISOR,
             ServicePort.DNS,  # tcp is redundant, making sure it's removed


### PR DESCRIPTION
This pull request updates the `node_cli/core/nftables.py` file to improve the handling of the Watchdog service ports by splitting them into separate HTTP and HTTPS ports. It also ensures that both ports are consistently used in firewall setup and cleanup logic.

**Firewall port management improvements:**

* Split the `ServicePort.WATCHDOG` constant into `ServicePort.WATCHDOG_HTTP` and `ServicePort.WATCHDOG_HTTPS` to clearly distinguish between HTTP and HTTPS ports for the Watchdog service.
* Updated the firewall setup (`setup_firewall`) and legacy rule cleanup (`cleanup_legacy_rules`) methods to use both `WATCHDOG_HTTP` and `WATCHDOG_HTTPS` ports instead of the previous single `WATCHDOG` port. [[1]](diffhunk://#diff-bac4f83ba810899f015d2f58ba8fa15484be66467bd0f461b35fd1ee061beec5L564-R566) [[2]](diffhunk://#diff-bac4f83ba810899f015d2f58ba8fa15484be66467bd0f461b35fd1ee061beec5L604-R607)

**Code organization:**

* Moved the `dataclass` import to the correct location for consistency with other imports.