### PR TITLE
Rename disk mountpoint to block device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,7 +113,7 @@ node_cli/cli/info.py
 
 meta.json
 
-disk_mountpoint.txt
+block_device.txt
 sgx_server_url.txt
 resource_allocation.json
 conf.json

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Arguments:
 Required environment variables in `ENV_FILE`:
 
 * `SGX_SERVER_URL` - SGX server URL.
-* `DISK_MOUNTPOINT` - Mount point for storing sChains data.
+* `BLOCK_DEVICE` - Absolute path to a dedicated raw block device (e.g. /dev/sdc)
 * `DOCKER_LVMPY_STREAM` - Stream of `docker-lvmpy` to use.
 * `NODE_VERSION` - Stream of `skale-node` to use.
 * `ENDPOINT` - RPC endpoint of the network where SKALE Manager is deployed.
@@ -566,7 +566,7 @@ Arguments:
 
 Required environment variables in `ENV_FILE`:
 
-* `DISK_MOUNTPOINT` - Mount point for storing sChain data.
+* `BLOCK_DEVICE` - Absolute path to a dedicated raw block device (e.g. /dev/sdc).
 * `DOCKER_LVMPY_STREAM` - Stream of `docker-lvmpy`.
 * `NODE_VERSION` - Stream of `skale-node`.
 * `ENDPOINT` - RPC endpoint of the network where SKALE Manager is deployed.
@@ -679,7 +679,7 @@ Arguments:
 Required environment variables in `ENV_FILE`:
 
 * `SGX_SERVER_URL` - SGX server URL.
-* `DISK_MOUNTPOINT` - Mount point for storing data (BTRFS recommended).
+* `BLOCK_DEVICE` - Absolute path to a dedicated raw block device (e.g. /dev/sdc).
 * `NODE_VERSION` - Stream of `skale-node` configs.
 * `ENDPOINT` - RPC endpoint of the network where Fair Manager is deployed.
 * `MANAGER_CONTRACTS` - SKALE Manager alias or address.
@@ -733,7 +733,7 @@ Arguments:
 Required environment variables in `ENV_FILE`:
 
 * `SGX_SERVER_URL` - SGX server URL.
-* `DISK_MOUNTPOINT` - Mount point for storing data (BTRFS recommended).
+* `BLOCK_DEVICE` - Absolute path to a dedicated raw block device (e.g. /dev/sdc).
 * `NODE_VERSION` - Stream of `skale-node` configs.
 * `ENDPOINT` - RPC endpoint of the network where Fair Manager is deployed.
 * `MANAGER_CONTRACTS` - SKALE Manager alias or address.
@@ -786,7 +786,7 @@ Required environment variables in `ENV_FILEPATH`:
 * `NODE_VERSION` - Stream of `skale-node` configs (e.g., `fair-main`).
 * `BOOT_ENDPOINT` - RPC endpoint of the Fair network (e.g., `https://rpc.fair.cloud/`).
 * `SGX_SERVER_URL` - SGX server URL (e.g., `https://127.0.0.1:1026/`).
-* `DISK_MOUNTPOINT` - Mount point for storing data (e.g., `/dev/sdc`).
+* `BLOCK_DEVICE` - Absolute path to a dedicated raw block device (e.g., `/dev/sdc`).
 * `ENV_TYPE` - Environment type (e.g., `mainnet`).
 
 Optional variables:
@@ -824,7 +824,7 @@ Required environment variables in `ENV_FILEPATH`:
 * `NODE_VERSION` - Stream of `skale-node` configs (e.g., `fair-main`).
 * `BOOT_ENDPOINT` - RPC endpoint of the Fair network (e.g., `https://rpc.fair.cloud/`).
 * `SGX_SERVER_URL` - SGX server URL (e.g., `https://127.0.0.1:1026/`).
-* `DISK_MOUNTPOINT` - Mount point for storing data (e.g., `/dev/sdc`).
+* `BLOCK_DEVICE` - Absolute path to a dedicated raw block device (e.g., `/dev/sdc`).
 * `ENV_TYPE` - Environment type (e.g., `mainnet`).
 
 Optional variables:
@@ -855,7 +855,7 @@ Required environment variables in `ENV_FILEPATH`:
 * `NODE_VERSION` - Stream of `skale-node` configs (e.g., `fair-main`).
 * `BOOT_ENDPOINT` - RPC endpoint of the Fair network (e.g., `https://rpc.fair.cloud/`).
 * `SGX_SERVER_URL` - SGX server URL (e.g., `https://127.0.0.1:1026/`).
-* `DISK_MOUNTPOINT` - Mount point for storing data (e.g., `/dev/sdc`).
+* `BLOCK_DEVICE` - Absolute path to a dedicated raw block device (e.g., `/dev/sdc`).
 * `ENV_TYPE` - Environment type (e.g., `mainnet`).
 
 Optional variables:
@@ -1100,7 +1100,7 @@ Required environment variables in `ENV_FILEPATH`:
 * `FAIR_CONTRACTS` - Fair Manager contracts alias or address.
 * `NODE_VERSION` - Stream of `skale-node` configs.
 * `BOOT_ENDPOINT` - RPC endpoint of Fair network.
-* `DISK_MOUNTPOINT` - Mount point for storing chain data.
+* `BLOCK_DEVICE` - Absolute path to a dedicated raw block device (e.g., `/dev/sdc`).
 * `ENV_TYPE` - Environment type (e.g., `mainnet`, `devnet`).
 
 Options:

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ SKALE Node CLI, part of the SKALE suite of validator tools, is the command line 
 
 Ensure that the following packages are installed: **docker**, **docker-compose** (1.27.4+)
 
-### Standard Node Binary
+### SKALE Node Binary
 
-This binary (`skale-VERSION-OS`) is used for managing standard SKALE validator nodes.
+This binary (`skale-VERSION-OS`) is used for managing SKALE validator nodes.
 
 ```shell
 # Replace {version} with the desired release version (e.g., 3.0.0)
@@ -54,19 +54,9 @@ CLI_VERSION={version} && \
 sudo -E bash -c "curl -L https://github.com/skalenetwork/node-cli/releases/download/$CLI_VERSION/skale-$CLI_VERSION-`uname -s`-`uname -m` > /usr/local/bin/skale"
 ```
 
-### Passive Node Binary
-
-This binary (`skale-VERSION-OS-passive`) is used for managing dedicated Passive nodes. **Ensure you download the correct `-passive` suffixed binary for Passive node operations.**
-
-```shell
-# Replace {version} with the desired release version (e.g., 3.0.0)
-CLI_VERSION={version} && \
-sudo -E bash -c "curl -L https://github.com/skalenetwork/node-cli/releases/download/$CLI_VERSION/skale-$CLI_VERSION-`uname -s`-`uname -m`-passive > /usr/local/bin/skale"
-```
-
 ### Fair Node Binary
 
-This binary (`skale-VERSION-OS-fair`) is used specifically for managing nodes on the Fair network.
+This binary (`skale-VERSION-OS-fair`) is used for managing nodes on the Fair network.
 
 ```shell
 # Replace {version} with the desired release version (e.g., 3.0.0)
@@ -158,8 +148,8 @@ Required environment variables in `ENV_FILE`:
 
 * `SGX_SERVER_URL` - SGX server URL.
 * `BLOCK_DEVICE` - Absolute path to a dedicated raw block device (e.g. /dev/sdc)
-* `DOCKER_LVMPY_STREAM` - Stream of `docker-lvmpy` to use.
-* `NODE_VERSION` - Stream of `skale-node` to use.
+* `DOCKER_LVMPY_VERSION` - Version of `docker-lvmpy`.
+* `NODE_VERSION` - Version of `skale-node`.
 * `ENDPOINT` - RPC endpoint of the network where SKALE Manager is deployed.
 * `MANAGER_CONTRACTS` - SKALE Manager `message_proxy_mainnet` contract alias or address.
 * `IMA_CONTRACTS` - IMA `skale_manager` contract alias or address.
@@ -567,8 +557,8 @@ Arguments:
 Required environment variables in `ENV_FILE`:
 
 * `BLOCK_DEVICE` - Absolute path to a dedicated raw block device (e.g. /dev/sdc).
-* `DOCKER_LVMPY_STREAM` - Stream of `docker-lvmpy`.
-* `NODE_VERSION` - Stream of `skale-node`.
+* `DOCKER_LVMPY_VERSION` - Version of `docker-lvmpy`.
+* `NODE_VERSION` - Version of `skale-node`.
 * `ENDPOINT` - RPC endpoint of the network where SKALE Manager is deployed.
 * `MANAGER_CONTRACTS` - SKALE Manager alias or address.
 * `IMA_CONTRACTS` - IMA alias or address.
@@ -680,7 +670,7 @@ Required environment variables in `ENV_FILE`:
 
 * `SGX_SERVER_URL` - SGX server URL.
 * `BLOCK_DEVICE` - Absolute path to a dedicated raw block device (e.g. /dev/sdc).
-* `NODE_VERSION` - Stream of `skale-node` configs.
+* `NODE_VERSION` - Version of `skale-node`.
 * `ENDPOINT` - RPC endpoint of the network where Fair Manager is deployed.
 * `MANAGER_CONTRACTS` - SKALE Manager alias or address.
 * `IMA_CONTRACTS` - IMA alias or address (*Note: Required by boot service, may not be used by Fair itself*).
@@ -734,7 +724,7 @@ Required environment variables in `ENV_FILE`:
 
 * `SGX_SERVER_URL` - SGX server URL.
 * `BLOCK_DEVICE` - Absolute path to a dedicated raw block device (e.g. /dev/sdc).
-* `NODE_VERSION` - Stream of `skale-node` configs.
+* `NODE_VERSION` - Version of `skale-node`.
 * `ENDPOINT` - RPC endpoint of the network where Fair Manager is deployed.
 * `MANAGER_CONTRACTS` - SKALE Manager alias or address.
 * `IMA_CONTRACTS` - IMA alias or address (*Note: Required by boot service, may not be used by Fair itself*).
@@ -783,7 +773,7 @@ Arguments:
 Required environment variables in `ENV_FILEPATH`:
 
 * `FAIR_CONTRACTS` - Fair contracts alias or address (e.g., `mainnet`).
-* `NODE_VERSION` - Stream of `skale-node` configs (e.g., `fair-main`).
+* `NODE_VERSION` - Version of `skale-node`.
 * `BOOT_ENDPOINT` - RPC endpoint of the Fair network (e.g., `https://rpc.fair.cloud/`).
 * `SGX_SERVER_URL` - SGX server URL (e.g., `https://127.0.0.1:1026/`).
 * `BLOCK_DEVICE` - Absolute path to a dedicated raw block device (e.g., `/dev/sdc`).
@@ -821,7 +811,7 @@ Arguments:
 Required environment variables in `ENV_FILEPATH`:
 
 * `FAIR_CONTRACTS` - Fair contracts alias or address (e.g., `mainnet`).
-* `NODE_VERSION` - Stream of `skale-node` configs (e.g., `fair-main`).
+* `NODE_VERSION` - Version of `skale-node`.
 * `BOOT_ENDPOINT` - RPC endpoint of the Fair network (e.g., `https://rpc.fair.cloud/`).
 * `SGX_SERVER_URL` - SGX server URL (e.g., `https://127.0.0.1:1026/`).
 * `BLOCK_DEVICE` - Absolute path to a dedicated raw block device (e.g., `/dev/sdc`).
@@ -852,7 +842,7 @@ Arguments:
 Required environment variables in `ENV_FILEPATH`:
 
 * `FAIR_CONTRACTS` - Fair contracts alias or address (e.g., `mainnet`).
-* `NODE_VERSION` - Stream of `skale-node` configs (e.g., `fair-main`).
+* `NODE_VERSION` - Version of `skale-node`.
 * `BOOT_ENDPOINT` - RPC endpoint of the Fair network (e.g., `https://rpc.fair.cloud/`).
 * `SGX_SERVER_URL` - SGX server URL (e.g., `https://127.0.0.1:1026/`).
 * `BLOCK_DEVICE` - Absolute path to a dedicated raw block device (e.g., `/dev/sdc`).
@@ -1098,7 +1088,7 @@ Arguments:
 Required environment variables in `ENV_FILEPATH`:
 
 * `FAIR_CONTRACTS` - Fair Manager contracts alias or address.
-* `NODE_VERSION` - Stream of `skale-node` configs.
+* `NODE_VERSION` - Version of `skale-node`.
 * `BOOT_ENDPOINT` - RPC endpoint of Fair network.
 * `BLOCK_DEVICE` - Absolute path to a dedicated raw block device (e.g., `/dev/sdc`).
 * `ENV_TYPE` - Environment type (e.g., `mainnet`, `devnet`).

--- a/node_cli/cli/__init__.py
+++ b/node_cli/cli/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.1.0'
+__version__ = '3.2.0'
 
 if __name__ == '__main__':
     print(__version__)

--- a/node_cli/configs/user.py
+++ b/node_cli/configs/user.py
@@ -117,7 +117,7 @@ class SkaleUserConfig(BaseUserConfig):
     endpoint: str
     manager_contracts: str
     ima_contracts: str
-    docker_lvmpy_stream: str
+    docker_lvmpy_version: str
     sgx_server_url: str
     monitoring_containers: str = ''
     telegraf: str = ''

--- a/node_cli/configs/user.py
+++ b/node_cli/configs/user.py
@@ -53,7 +53,7 @@ class BaseUserConfig(ABC):
     node_version: str
     env_type: str
     filebeat_host: str
-    disk_mountpoint: str
+    block_device: str
 
     container_configs_dir: str = ''
     skip_docker_config: str = ''

--- a/node_cli/core/node.py
+++ b/node_cli/core/node.py
@@ -540,7 +540,7 @@ def run_checks(
 
     if disk is None:
         env_config = get_validated_user_config(node_type=node_type, node_mode=node_mode)
-        disk = env_config.disk_mountpoint
+        disk = env_config.block_device
     failed_checks = run_host_checks(disk, node_type, node_mode, network, container_config_path)
     if not failed_checks:
         print('Requirements checking successfully finished!')

--- a/node_cli/operations/base.py
+++ b/node_cli/operations/base.py
@@ -82,7 +82,7 @@ def checked_host(func):
     def wrapper(env_filepath: str, env: Dict, node_mode: NodeMode, *args, **kwargs):
         download_skale_node(env.get('NODE_VERSION'), env.get('CONTAINER_CONFIGS_DIR'))
         failed_checks = run_host_checks(
-            env['DISK_MOUNTPOINT'],
+            env['BLOCK_DEVICE'],
             TYPE,
             node_mode,
             env['ENV_TYPE'],
@@ -98,7 +98,7 @@ def checked_host(func):
             return result
 
         failed_checks = run_host_checks(
-            env['DISK_MOUNTPOINT'],
+            env['BLOCK_DEVICE'],
             TYPE,
             node_mode,
             env['ENV_TYPE'],
@@ -160,7 +160,7 @@ def update(env_filepath: str, env: Dict, node_type: NodeType, node_mode: NodeMod
 def update_fair_boot(env_filepath: str, env: Dict, node_mode: NodeMode = NodeMode.ACTIVE) -> bool:
     compose_rm(node_type=NodeType.FAIR, node_mode=node_mode, env=env)
     remove_dynamic_containers()
-    cleanup_volume_artifacts(env['DISK_MOUNTPOINT'])
+    cleanup_volume_artifacts(env['BLOCK_DEVICE'])
 
     sync_skale_node()
     ensure_btrfs_kernel_module_autoloaded()
@@ -172,7 +172,7 @@ def update_fair_boot(env_filepath: str, env: Dict, node_mode: NodeMode = NodeMod
     configure_nftables(enable_monitoring=enable_monitoring)
 
     generate_nginx_config()
-    prepare_block_device(env['DISK_MOUNTPOINT'], force=env['ENFORCE_BTRFS'] == 'True')
+    prepare_block_device(env['BLOCK_DEVICE'], force=env['ENFORCE_BTRFS'] == 'True')
 
     prepare_host(env_filepath, env['ENV_TYPE'])
 
@@ -237,7 +237,7 @@ def init(env_filepath: str, env: dict, node_type: NodeType, node_mode: NodeMode)
 @checked_host
 def init_fair_boot(env_filepath: str, env: dict, node_mode: NodeMode = NodeMode.ACTIVE) -> None:
     sync_skale_node()
-    cleanup_volume_artifacts(env['DISK_MOUNTPOINT'])
+    cleanup_volume_artifacts(env['BLOCK_DEVICE'])
 
     ensure_btrfs_kernel_module_autoloaded()
     if env.get('SKIP_DOCKER_CONFIG') != 'True':
@@ -253,7 +253,7 @@ def init_fair_boot(env_filepath: str, env: dict, node_mode: NodeMode = NodeMode.
     configure_filebeat()
     configure_flask()
     generate_nginx_config()
-    prepare_block_device(env['DISK_MOUNTPOINT'], force=env['ENFORCE_BTRFS'] == 'True')
+    prepare_block_device(env['BLOCK_DEVICE'], force=env['ENFORCE_BTRFS'] == 'True')
 
     meta_manager = FairCliMetaManager()
     meta_manager.update_meta(
@@ -275,7 +275,7 @@ def init_passive(
     snapshot: bool,
     snapshot_from: Optional[str],
 ) -> None:
-    cleanup_volume_artifacts(env['DISK_MOUNTPOINT'])
+    cleanup_volume_artifacts(env['BLOCK_DEVICE'])
     download_skale_node(env.get('NODE_VERSION'), env.get('CONTAINER_CONFIGS_DIR'))
     sync_skale_node()
 
@@ -296,7 +296,7 @@ def init_passive(
     link_env_file()
 
     generate_nginx_config()
-    prepare_block_device(env['DISK_MOUNTPOINT'], force=env['ENFORCE_BTRFS'] == 'True')
+    prepare_block_device(env['BLOCK_DEVICE'], force=env['ENFORCE_BTRFS'] == 'True')
 
     meta_manager = CliMetaManager()
     meta_manager.update_meta(
@@ -320,7 +320,7 @@ def init_passive(
 def update_passive(env_filepath: str, env: Dict) -> bool:
     compose_rm(env=env, node_type=NodeType.SKALE, node_mode=NodeMode.PASSIVE)
     remove_dynamic_containers()
-    cleanup_volume_artifacts(env['DISK_MOUNTPOINT'])
+    cleanup_volume_artifacts(env['BLOCK_DEVICE'])
     download_skale_node(env['NODE_VERSION'], env.get('CONTAINER_CONFIGS_DIR'))
     sync_skale_node()
 
@@ -332,7 +332,7 @@ def update_passive(env_filepath: str, env: Dict) -> bool:
 
     ensure_filestorage_mapping()
 
-    prepare_block_device(env['DISK_MOUNTPOINT'], force=env['ENFORCE_BTRFS'] == 'True')
+    prepare_block_device(env['BLOCK_DEVICE'], force=env['ENFORCE_BTRFS'] == 'True')
     generate_nginx_config()
 
     prepare_host(env_filepath, env['ENV_TYPE'], allocation=True)
@@ -381,7 +381,7 @@ def restore(env, backup_path, node_type: NodeType, config_only=False):
     node_mode = upsert_node_mode(node_mode=NodeMode.ACTIVE)
     unpack_backup_archive(backup_path)
     failed_checks = run_host_checks(
-        env['DISK_MOUNTPOINT'],
+        env['BLOCK_DEVICE'],
         TYPE,
         node_mode,
         env['ENV_TYPE'],
@@ -416,7 +416,7 @@ def restore(env, backup_path, node_type: NodeType, config_only=False):
         compose_up(env=env, node_type=node_type, node_mode=node_mode)
 
     failed_checks = run_host_checks(
-        env['DISK_MOUNTPOINT'],
+        env['BLOCK_DEVICE'],
         TYPE,
         node_mode,
         env['ENV_TYPE'],

--- a/node_cli/operations/base.py
+++ b/node_cli/operations/base.py
@@ -147,7 +147,7 @@ def update(env_filepath: str, env: Dict, node_type: NodeType, node_mode: NodeMod
     meta_manager.update_meta(
         VERSION,
         env['NODE_VERSION'],
-        env['DOCKER_LVMPY_STREAM'],
+        env['DOCKER_LVMPY_VERSION'],
         distro.id(),
         distro.version(),
     )
@@ -224,7 +224,7 @@ def init(env_filepath: str, env: dict, node_type: NodeType, node_mode: NodeMode)
     meta_manager.update_meta(
         VERSION,
         env['NODE_VERSION'],
-        env['DOCKER_LVMPY_STREAM'],
+        env['DOCKER_LVMPY_VERSION'],
         distro.id(),
         distro.version(),
     )
@@ -341,7 +341,7 @@ def update_passive(env_filepath: str, env: Dict) -> bool:
     meta_manager.update_meta(
         VERSION,
         env['NODE_VERSION'],
-        env['DOCKER_LVMPY_STREAM'],
+        env['DOCKER_LVMPY_VERSION'],
         distro.id(),
         distro.version(),
     )
@@ -363,7 +363,7 @@ def turn_on(env: dict, node_type: NodeType, node_mode: NodeMode) -> None:
     meta_manager.update_meta(
         VERSION,
         env['NODE_VERSION'],
-        env['DOCKER_LVMPY_STREAM'],
+        env['DOCKER_LVMPY_VERSION'],
         distro.id(),
         distro.version(),
     )
@@ -408,7 +408,7 @@ def restore(env, backup_path, node_type: NodeType, config_only=False):
     meta_manager.update_meta(
         VERSION,
         env['NODE_VERSION'],
-        env['DOCKER_LVMPY_STREAM'],
+        env['DOCKER_LVMPY_VERSION'],
         distro.id(),
         distro.version(),
     )

--- a/node_cli/operations/docker_lvmpy.py
+++ b/node_cli/operations/docker_lvmpy.py
@@ -57,7 +57,7 @@ def ensure_filestorage_mapping(mapping_dir=FILESTORAGE_MAPPING):
 def sync_docker_lvmpy_repo(env):
     if os.path.isdir(DOCKER_LVMPY_PATH):
         shutil.rmtree(DOCKER_LVMPY_PATH)
-    sync_repo(DOCKER_LVMPY_REPO_URL, DOCKER_LVMPY_PATH, env['DOCKER_LVMPY_STREAM'])
+    sync_repo(DOCKER_LVMPY_REPO_URL, DOCKER_LVMPY_PATH, env['DOCKER_LVMPY_VERSION'])
 
 
 def lvmpy_install(env):

--- a/node_cli/operations/docker_lvmpy.py
+++ b/node_cli/operations/docker_lvmpy.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 
 def update_docker_lvmpy_env(env):
-    env['PHYSICAL_VOLUME'] = env['DISK_MOUNTPOINT']
+    env['PHYSICAL_VOLUME'] = env['BLOCK_DEVICE']
     env['VOLUME_GROUP'] = 'schains'
     env['FILESTORAGE_MAPPING'] = FILESTORAGE_MAPPING
     env['MNT_DIR'] = SCHAINS_MNT_DIR_REGULAR
@@ -64,7 +64,7 @@ def lvmpy_install(env):
     ensure_filestorage_mapping()
     logging.info('Configuring and starting lvmpy')
     setup_lvmpy(
-        block_device=env['DISK_MOUNTPOINT'], volume_group=VOLUME_GROUP, exec_start=LVMPY_RUN_CMD
+        block_device=env['BLOCK_DEVICE'], volume_group=VOLUME_GROUP, exec_start=LVMPY_RUN_CMD
     )
     init_healing_cron()
     logger.info('docker-lvmpy is configured and started')

--- a/node_cli/operations/fair.py
+++ b/node_cli/operations/fair.py
@@ -90,7 +90,7 @@ def init(
 ) -> bool:
     sync_skale_node()
     ensure_btrfs_kernel_module_autoloaded()
-    cleanup_volume_artifacts(env['DISK_MOUNTPOINT'])
+    cleanup_volume_artifacts(env['BLOCK_DEVICE'])
 
     if env.get('SKIP_DOCKER_CONFIG') != 'True':
         configure_docker()
@@ -103,7 +103,7 @@ def init(
     prepare_host(env_filepath, env_type=env['ENV_TYPE'])
     link_env_file()
 
-    prepare_block_device(env['DISK_MOUNTPOINT'], force=env['ENFORCE_BTRFS'] == 'True')
+    prepare_block_device(env['BLOCK_DEVICE'], force=env['ENFORCE_BTRFS'] == 'True')
 
     update_images(env=env, node_type=NodeType.FAIR, node_mode=node_mode)
     compose_up(
@@ -135,7 +135,7 @@ def init(
 def update_fair_boot(env_filepath: str, env: dict, node_mode: NodeMode = NodeMode.ACTIVE) -> bool:
     compose_rm(node_type=NodeType.FAIR, node_mode=node_mode, env=env)
     remove_dynamic_containers()
-    cleanup_volume_artifacts(env['DISK_MOUNTPOINT'])
+    cleanup_volume_artifacts(env['BLOCK_DEVICE'])
 
     sync_skale_node()
     ensure_btrfs_kernel_module_autoloaded()
@@ -147,7 +147,7 @@ def update_fair_boot(env_filepath: str, env: dict, node_mode: NodeMode = NodeMod
     configure_nftables(enable_monitoring=enable_monitoring)
 
     generate_nginx_config()
-    prepare_block_device(env['DISK_MOUNTPOINT'], force=env['ENFORCE_BTRFS'] == 'True')
+    prepare_block_device(env['BLOCK_DEVICE'], force=env['ENFORCE_BTRFS'] == 'True')
 
     prepare_host(env_filepath, env['ENV_TYPE'])
 
@@ -234,7 +234,7 @@ def update(
 def restore(node_mode: NodeMode, env, backup_path, config_only=False):
     unpack_backup_archive(backup_path)
     failed_checks = run_host_checks(
-        env['DISK_MOUNTPOINT'],
+        env['BLOCK_DEVICE'],
         TYPE,
         node_mode,
         env['ENV_TYPE'],
@@ -267,7 +267,7 @@ def restore(node_mode: NodeMode, env, backup_path, config_only=False):
         compose_up(env=env, node_type=NodeType.FAIR, node_mode=node_mode)
 
     failed_checks = run_host_checks(
-        env['DISK_MOUNTPOINT'],
+        env['BLOCK_DEVICE'],
         TYPE,
         node_mode,
         env['ENV_TYPE'],

--- a/node_cli/operations/volume.py
+++ b/node_cli/operations/volume.py
@@ -42,7 +42,7 @@ class FilesystemExistsError(Exception):
 
 
 def update_docker_lvmpy_env(env):
-    env['PHYSICAL_VOLUME'] = env['DISK_MOUNTPOINT']
+    env['PHYSICAL_VOLUME'] = env['BLOCK_DEVICE']
     env['VOLUME_GROUP'] = 'schains'
     env['FILESTORAGE_MAPPING'] = FILESTORAGE_MAPPING
     env['SCHAINS_MNT_DIR'] = SCHAINS_MNT_DIR_REGULAR

--- a/node_cli/operations/volume.py
+++ b/node_cli/operations/volume.py
@@ -58,7 +58,7 @@ def ensure_filestorage_mapping(mapping_dir=FILESTORAGE_MAPPING):
 def sync_docker_lvmpy_repo(env):
     if os.path.isdir(DOCKER_LVMPY_PATH):
         shutil.rmtree(DOCKER_LVMPY_PATH)
-    sync_repo(DOCKER_LVMPY_REPO_URL, DOCKER_LVMPY_PATH, env['DOCKER_LVMPY_STREAM'])
+    sync_repo(DOCKER_LVMPY_REPO_URL, DOCKER_LVMPY_PATH, env['DOCKER_LVMPY_VERSION'])
 
 
 def docker_lvmpy_update(env):

--- a/node_cli/utils/meta.py
+++ b/node_cli/utils/meta.py
@@ -7,7 +7,7 @@ from node_cli.configs import META_FILEPATH
 
 DEFAULT_VERSION = '1.0.0'
 DEFAULT_CONFIG_STREAM = '1.1.0'
-DEFAULT_DOCKER_LVMPY_STREAM = '1.0.0'
+DEFAULT_DOCKER_LVMPY_VERSION = '1.0.0'
 DEFAULT_OS_ID = 'ubuntu'
 DEFAULT_OS_VERSION = '18.04'
 
@@ -26,13 +26,13 @@ class CliMetaBase(abc.ABC):
 
 @dataclass
 class CliMeta(CliMetaBase):
-    docker_lvmpy_stream: str = DEFAULT_DOCKER_LVMPY_STREAM
+    docker_lvmpy_version: str = DEFAULT_DOCKER_LVMPY_VERSION
 
     def asdict(self) -> dict:
         return {
             'version': self.version,
             'config_stream': self.config_stream,
-            'docker_lvmpy_stream': self.docker_lvmpy_stream,
+            'docker_lvmpy_version': self.docker_lvmpy_version,
             'os_id': self.os_id,
             'os_version': self.os_version,
         }
@@ -96,7 +96,7 @@ class CliMetaManager(BaseCliMetaManager):
     def compose_default_meta(self) -> CliMeta:
         return CliMeta(
             version=DEFAULT_VERSION,
-            docker_lvmpy_stream=DEFAULT_DOCKER_LVMPY_STREAM,
+            docker_lvmpy_version=DEFAULT_DOCKER_LVMPY_VERSION,
             config_stream=DEFAULT_CONFIG_STREAM,
             os_id=DEFAULT_OS_ID,
             os_version=DEFAULT_OS_VERSION,
@@ -106,7 +106,7 @@ class CliMetaManager(BaseCliMetaManager):
         self,
         version: str,
         config_stream: str,
-        docker_lvmpy_stream: str | None,
+        docker_lvmpy_version: str | None,
         os_id: str,
         os_version: str,
     ) -> None:
@@ -116,7 +116,7 @@ class CliMetaManager(BaseCliMetaManager):
             config_stream,
             os_id,
             os_version,
-            docker_lvmpy_stream,
+            docker_lvmpy_version,
         )
         self.save_meta(meta)
 

--- a/node_cli/utils/print_formatters.py
+++ b/node_cli/utils/print_formatters.py
@@ -319,7 +319,7 @@ def print_meta_info(meta_info: CliMeta) -> None:
         {LONG_LINE}
         Version: {meta_info.version}
         Config Stream: {meta_info.config_stream}
-        Lvmpy stream: {meta_info.docker_lvmpy_stream}
+        Lvmpy stream: {meta_info.docker_lvmpy_version}
         {LONG_LINE}
     """)
     )

--- a/tests/cli/node_test.py
+++ b/tests/cli/node_test.py
@@ -471,5 +471,5 @@ def test_node_version(meta_file_v2):
         assert result.exit_code == 0
         assert (
             result.output
-            == "{'version': '0.1.1', 'config_stream': 'develop', 'docker_lvmpy_stream': '1.1.2'}\n"
+            == "{'version': '0.1.1', 'config_stream': 'develop', 'docker_lvmpy_version': '1.1.2'}\n"
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -298,7 +298,7 @@ def valid_env_params():
         'FILEBEAT_HOST': '127.0.0.1:3010',
         'SGX_SERVER_URL': 'http://127.0.0.1',
         'BLOCK_DEVICE': '/dev/sss',
-        'DOCKER_LVMPY_STREAM': 'master',
+        'DOCKER_LVMPY_VERSION': 'master',
         'ENV_TYPE': 'devnet',
         'SCHAIN_NAME': 'test',
         'ENFORCE_BTRFS': 'False',
@@ -363,7 +363,7 @@ def regular_user_conf(tmp_path):
         FILEBEAT_HOST=127.0.0.1:3010
         SGX_SERVER_URL=http://127.0.0.1
         BLOCK_DEVICE=/dev/sss
-        DOCKER_LVMPY_STREAM='master'
+        DOCKER_LVMPY_VERSION='master'
         ENV_TYPE='devnet'
         MANAGER_CONTRACTS='test-manager'
         IMA_CONTRACTS='test-ima'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -297,7 +297,7 @@ def valid_env_params():
         'NODE_VERSION': 'master',
         'FILEBEAT_HOST': '127.0.0.1:3010',
         'SGX_SERVER_URL': 'http://127.0.0.1',
-        'DISK_MOUNTPOINT': '/dev/sss',
+        'BLOCK_DEVICE': '/dev/sss',
         'DOCKER_LVMPY_STREAM': 'master',
         'ENV_TYPE': 'devnet',
         'SCHAIN_NAME': 'test',
@@ -362,7 +362,7 @@ def regular_user_conf(tmp_path):
         NODE_VERSION='main'
         FILEBEAT_HOST=127.0.0.1:3010
         SGX_SERVER_URL=http://127.0.0.1
-        DISK_MOUNTPOINT=/dev/sss
+        BLOCK_DEVICE=/dev/sss
         DOCKER_LVMPY_STREAM='master'
         ENV_TYPE='devnet'
         MANAGER_CONTRACTS='test-manager'
@@ -384,7 +384,7 @@ def fair_user_conf(tmp_path):
         NODE_VERSION='main'
         FILEBEAT_HOST=127.0.0.1:3010
         SGX_SERVER_URL=http://127.0.0.1
-        DISK_MOUNTPOINT=/dev/sss
+        BLOCK_DEVICE=/dev/sss
         ENV_TYPE='devnet'
         ENFORCE_BTRFS=False
         FAIR_CONTRACTS='test-fair'
@@ -405,7 +405,7 @@ def fair_boot_user_conf(tmp_path):
         NODE_VERSION='main'
         FILEBEAT_HOST=127.0.0.1:3010
         SGX_SERVER_URL=http://127.0.0.1
-        DISK_MOUNTPOINT=/dev/sss
+        BLOCK_DEVICE=/dev/sss
         ENV_TYPE='devnet'
         MANAGER_CONTRACTS='test-manager'
         IMA_CONTRACTS='test-ima'
@@ -425,7 +425,7 @@ def passive_user_conf(tmp_path):
         ENDPOINT=http://localhost:8545
         NODE_VERSION='main'
         FILEBEAT_HOST=127.0.0.1:3010
-        DISK_MOUNTPOINT=/dev/sss
+        BLOCK_DEVICE=/dev/sss
         ENV_TYPE='devnet'
         SCHAIN_NAME='test-schain'
         ENFORCE_BTRFS=False

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -34,12 +34,12 @@ TEST_SCHAINS_MNT_DIR_SINGLE_CHAIN = 'tests/tmp'
 
 TEST_META_V1 = {'version': '0.1.1', 'config_stream': 'develop'}
 
-TEST_META_V2 = {'version': '0.1.1', 'config_stream': 'develop', 'docker_lvmpy_stream': '1.1.2'}
+TEST_META_V2 = {'version': '0.1.1', 'config_stream': 'develop', 'docker_lvmpy_version': '1.1.2'}
 
 TEST_META_V3 = {
     'version': '0.1.1',
     'config_stream': 'develop',
-    'docker_lvmpy_stream': '1.1.2',
+    'docker_lvmpy_version': '1.1.2',
     'os_id': 'ubuntu',
     'os_version': '18.04',
 }

--- a/tests/tools_meta_test.py
+++ b/tests/tools_meta_test.py
@@ -17,21 +17,21 @@ def test_get_meta_info_v1(meta_file_v1):
     meta = CliMetaManager().get_meta_info()
     assert meta.version == TEST_META_V1['version']
     assert meta.config_stream == TEST_META_V1['config_stream']
-    assert meta.docker_lvmpy_stream == '1.0.0'
+    assert meta.docker_lvmpy_version == '1.0.0'
 
 
 def test_get_meta_info_v2(meta_file_v2):
     meta = CliMetaManager().get_meta_info()
     assert meta.version == TEST_META_V2['version']
     assert meta.config_stream == TEST_META_V2['config_stream']
-    assert meta.docker_lvmpy_stream == TEST_META_V2['docker_lvmpy_stream']
+    assert meta.docker_lvmpy_version == TEST_META_V2['docker_lvmpy_version']
 
 
 def test_get_meta_info_v3(meta_file_v3):
     meta = CliMetaManager().get_meta_info()
     assert meta.version == TEST_META_V3['version']
     assert meta.config_stream == TEST_META_V3['config_stream']
-    assert meta.docker_lvmpy_stream == TEST_META_V3['docker_lvmpy_stream']
+    assert meta.docker_lvmpy_version == TEST_META_V3['docker_lvmpy_version']
     assert meta.os_id == TEST_META_V3['os_id']
     assert meta.os_version == TEST_META_V3['os_version']
 
@@ -45,7 +45,7 @@ def test_compose_default_meta():
     meta = CliMetaManager().compose_default_meta()
     assert meta.version == '1.0.0'
     assert meta.config_stream == '1.1.0'
-    assert meta.docker_lvmpy_stream == '1.0.0'
+    assert meta.docker_lvmpy_version == '1.0.0'
     assert meta.os_id == 'ubuntu'
     assert meta.os_version == '18.04'
 
@@ -58,7 +58,7 @@ def test_save_meta(meta_file_v2):
     assert saved_json == {
         'version': '1.1.2',
         'config_stream': '2.2.2',
-        'docker_lvmpy_stream': '1.0.0',
+        'docker_lvmpy_version': '1.0.0',
         'os_id': 'ubuntu',
         'os_version': '18.04',
     }
@@ -69,14 +69,14 @@ def test_update_meta_from_v2_to_v3(meta_file_v2):
     CliMetaManager().update_meta(
         version='3.3.3',
         config_stream='1.1.1',
-        docker_lvmpy_stream='1.2.2',
+        docker_lvmpy_version='1.2.2',
         os_id='debian',
         os_version='11',
     )
     meta = CliMetaManager().get_meta_info()
     assert meta.version == '3.3.3'
     assert meta.config_stream == '1.1.1'
-    assert meta.docker_lvmpy_stream == '1.2.2'
+    assert meta.docker_lvmpy_version == '1.2.2'
     assert meta.os_id == 'debian'
     assert meta.os_version == '11'
     assert meta != old_meta
@@ -86,14 +86,14 @@ def test_update_meta_from_v1(meta_file_v1):
     CliMetaManager().update_meta(
         version='4.4.4',
         config_stream='beta',
-        docker_lvmpy_stream='1.3.3',
+        docker_lvmpy_version='1.3.3',
         os_id='debian',
         os_version='11',
     )
     meta = CliMetaManager().get_meta_info()
     assert meta.version == '4.4.4'
     assert meta.config_stream == 'beta'
-    assert meta.docker_lvmpy_stream == '1.3.3'
+    assert meta.docker_lvmpy_version == '1.3.3'
     assert meta.os_id == 'debian'
     assert meta.os_version == '11'
 
@@ -102,14 +102,14 @@ def test_update_meta_from_v3(meta_file_v3):
     CliMetaManager().update_meta(
         version='5.5.5',
         config_stream='stable',
-        docker_lvmpy_stream='1.2.3',
+        docker_lvmpy_version='1.2.3',
         os_id='ubuntu',
         os_version='20.04',
     )
     meta = CliMetaManager().get_meta_info()
     assert meta.version == '5.5.5'
     assert meta.config_stream == 'stable'
-    assert meta.docker_lvmpy_stream == '1.2.3'
+    assert meta.docker_lvmpy_version == '1.2.3'
     assert meta.os_id == 'ubuntu'
     assert meta.os_version == '20.04'
 
@@ -156,7 +156,7 @@ def test_fair_compose_default_meta():
     assert meta.config_stream == '1.1.0'
     assert meta.os_id == 'ubuntu'
     assert meta.os_version == '18.04'
-    assert not hasattr(meta, 'docker_lvmpy_stream')
+    assert not hasattr(meta, 'docker_lvmpy_version')
 
 
 def test_fair_save_meta(meta_file_v2):
@@ -172,7 +172,7 @@ def test_fair_save_meta(meta_file_v2):
         'os_id': 'debian',
         'os_version': '11',
     }
-    assert 'docker_lvmpy_stream' not in saved_json
+    assert 'docker_lvmpy_version' not in saved_json
 
 
 def test_fair_update_meta_from_v2_to_v3(meta_file_v2):
@@ -237,7 +237,7 @@ def test_fair_get_meta_info_raw(meta_file_v3):
     assert raw_meta['config_stream'] == TEST_META_V3['config_stream']
     assert raw_meta['os_id'] == TEST_META_V3['os_id']
     assert raw_meta['os_version'] == TEST_META_V3['os_version']
-    assert 'docker_lvmpy_stream' not in raw_meta
+    assert 'docker_lvmpy_version' not in raw_meta
 
 
 def test_fair_get_meta_info_raw_empty():
@@ -257,7 +257,7 @@ def test_fair_asdict():
         'os_version': '35',
     }
     assert meta_dict == expected
-    assert 'docker_lvmpy_stream' not in meta_dict
+    assert 'docker_lvmpy_version' not in meta_dict
 
 
 def test_fair_meta_compatibility_with_cli_meta_file(meta_file_v3):
@@ -266,21 +266,21 @@ def test_fair_meta_compatibility_with_cli_meta_file(meta_file_v3):
     assert meta.config_stream == TEST_META_V3['config_stream']
     assert meta.os_id == TEST_META_V3['os_id']
     assert meta.os_version == TEST_META_V3['os_version']
-    # Should not have docker_lvmpy_stream even though it's in the file
-    assert not hasattr(meta, 'docker_lvmpy_stream')
+    # Should not have docker_lvmpy_version even though it's in the file
+    assert not hasattr(meta, 'docker_lvmpy_version')
 
 
 def test_fair_save_meta_overwrites_cli_meta(meta_file_v3):
     with open(META_FILEPATH) as f:
         original_data = json.load(f)
-    assert 'docker_lvmpy_stream' in original_data
+    assert 'docker_lvmpy_version' in original_data
 
     fair_meta = FairCliMeta(version='2.0.0', config_stream='fair-new')
     FairCliMetaManager().save_meta(fair_meta)
 
     with open(META_FILEPATH) as f:
         saved_data = json.load(f)
-    assert 'docker_lvmpy_stream' not in saved_data
+    assert 'docker_lvmpy_version' not in saved_data
     assert saved_data['version'] == '2.0.0'
     assert saved_data['config_stream'] == 'fair-new'
 


### PR DESCRIPTION
This pull request updates the node CLI and related documentation to standardize on the use of the `BLOCK_DEVICE` environment variable, replacing the previous `DISK_MOUNTPOINT` variable throughout the codebase, configuration, and documentation. This change ensures consistency and clarity in how the raw block device is specified for storage operations.

Key changes include:

**Environment Variable Standardization:**

* Replaced all references to `DISK_MOUNTPOINT` with `BLOCK_DEVICE` in the `README.md` documentation, clarifying that it should be the absolute path to a dedicated raw block device (e.g., `/dev/sdc`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L160-R160) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L569-R569) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L682-R682) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L736-R736) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L789-R789) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L827-R827) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L858-R858) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1103-R1103)

**Codebase Refactoring:**

* Updated the `BaseUserConfig` class and all code references to use `block_device` instead of `disk_mountpoint`, ensuring that all operations (e.g., checks, initialization, updates, restores) use the new variable. [[1]](diffhunk://#diff-f3abb734bd46614e5fda5d5ba9785676d736559df41db30ba7e6a73747c578b6L56-R56) [[2]](diffhunk://#diff-cd8b3a0d0a5921ad426729c3dbcd0ae7a148dd6772be2cc807da4316dd166050L543-R543) [[3]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L85-R85) [[4]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L101-R101) [[5]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L163-R163) [[6]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L175-R175) [[7]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L240-R240) [[8]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L256-R256) [[9]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L278-R278) [[10]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L299-R299) [[11]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L323-R323) [[12]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L335-R335) [[13]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L384-R384) [[14]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L419-R419) [[15]](diffhunk://#diff-1f32072a78a903b6d5fb191c0dbf53a0f8e39e1e7b126a240e0f628820280abaL44-R44) [[16]](diffhunk://#diff-1f32072a78a903b6d5fb191c0dbf53a0f8e39e1e7b126a240e0f628820280abaL67-R67) [[17]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cL93-R93) [[18]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cL106-R106) [[19]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cL138-R138) [[20]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cL150-R150) [[21]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cL237-R237) [[22]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cL270-R270) [[23]](diffhunk://#diff-74632cdab2c3e2932842ac4d28529a4ffa17d2d6e770d11c2e3a54e451c5bd36L45-R45)

**Testing Updates:**

* Modified test configuration and fixtures to use `BLOCK_DEVICE` in place of `DISK_MOUNTPOINT` for consistency in test environments. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L300-R300) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L365-R365)

**Version Bump:**

* Incremented the CLI version to `3.2.0` to reflect these breaking changes.