### PR TITLE
Fetch SSL check fix from develop

### DIFF
--- a/node_cli/core/ssl/check.py
+++ b/node_cli/core/ssl/check.py
@@ -196,8 +196,15 @@ def check_ssl_connection(host, port, silent=False):
     ]
     expose_output = not silent
     with detached_subprocess(ssl_check_cmd, expose_output=expose_output) as dp:
-        time.sleep(1)
-        code = dp.poll()
-        if code is not None:
+        for _ in range(10):
+            code = dp.poll()
+            if code is None:
+                logger.info('Healthcheck process still running...')
+                time.sleep(2)
+                continue
+            elif code == 0:
+                return
             logger.error('Healthcheck connection failed')
             raise SSLHealthcheckError('OpenSSL connection verification failed')
+        logger.error('Healthcheck timed-out')
+        raise SSLHealthcheckError('OpenSSL connection verification timed-out')

--- a/node_cli/core/ssl/check.py
+++ b/node_cli/core/ssl/check.py
@@ -20,6 +20,7 @@
 import time
 import socket
 import logging
+import subprocess
 from contextlib import contextmanager
 
 from node_cli.core.ssl.utils import detached_subprocess
@@ -196,15 +197,15 @@ def check_ssl_connection(host, port, silent=False):
     ]
     expose_output = not silent
     with detached_subprocess(ssl_check_cmd, expose_output=expose_output) as dp:
-        for _ in range(10):
-            code = dp.poll()
-            if code is None:
-                logger.info('Healthcheck process still running...')
-                time.sleep(2)
-                continue
-            elif code == 0:
-                return
-            logger.error('Healthcheck connection failed')
-            raise SSLHealthcheckError('OpenSSL connection verification failed')
-        logger.error('Healthcheck timed-out')
-        raise SSLHealthcheckError('OpenSSL connection verification timed-out')
+        timeout = 20
+        try:
+            dp.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            logger.error('Healthcheck timed-out after %s s', timeout)
+            raise SSLHealthcheckError('OpenSSL connection verification timed-out')
+
+        if dp.returncode == 0:  # success
+            return
+
+        logger.error('Healthcheck connection failed (code %s)', dp.returncode)
+        raise SSLHealthcheckError('OpenSSL connection verification failed')

--- a/node_cli/core/ssl/utils.py
+++ b/node_cli/core/ssl/utils.py
@@ -17,13 +17,13 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import logging
 import os
 import shutil
-import logging
 import subprocess
 from contextlib import contextmanager
-from node_cli.configs.ssl import SSL_CERT_FILEPATH, SSL_KEY_FILEPATH, SSL_FOLDER_PATH
 
+from node_cli.configs.ssl import SSL_CERT_FILEPATH, SSL_FOLDER_PATH, SSL_KEY_FILEPATH
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,13 @@ def is_ssl_folder_empty(ssl_path=SSL_FOLDER_PATH):
 @contextmanager
 def detached_subprocess(cmd, expose_output=False):
     logger.debug(f'Starting detached subprocess: {cmd}')
-    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
+    p = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        stdin=subprocess.DEVNULL,
+        encoding='utf-8',
+    )
     try:
         yield p
     finally:


### PR DESCRIPTION
This pull request improves the reliability and robustness of SSL connection checks by enhancing subprocess management and error handling. The main changes include adding a timeout to the SSL healthcheck process, improving subprocess invocation, and making minor import cleanups.

**SSL healthcheck improvements:**

* Added a 20-second timeout to the SSL connection healthcheck in `check_ssl_connection`, raising an error if the check takes too long and providing clearer error messages on failure.

**Subprocess management enhancements:**

* Modified the `detached_subprocess` context manager to explicitly close standard input (`stdin`) by setting it to `subprocess.DEVNULL`, which helps prevent potential deadlocks and resource leaks.

**Code cleanup:**

* Cleaned up import statements in `ssl/check.py` and `ssl/utils.py`, including adding the `subprocess` import and sorting SSL config imports for clarity. [[1]](diffhunk://#diff-808010dcf5eb7d6a495ef6f908da15f58f9625b09b0ed9849f80041700ac6277R23) [[2]](diffhunk://#diff-3525463c5ad49653cc6be51ea3a470960d2a1e3bfe2521403cc4faf7d6b333e2R20-R26)