### PR TITLE
Fix fair-api service name

### DIFF
--- a/node_cli/operations/fair.py
+++ b/node_cli/operations/fair.py
@@ -126,7 +126,7 @@ def init(
     )
 
     compose_up(env=env, node_type=NodeType.FAIR, node_mode=node_mode)
-    wait_for_container(BASE_PASSIVE_FAIR_COMPOSE_SERVICES['fair-api'])
+    wait_for_container(BASE_PASSIVE_FAIR_COMPOSE_SERVICES['api'])
     time.sleep(REDIS_START_TIMEOUT)
     return True
 


### PR DESCRIPTION

This pull request updates the container startup logic in the FAIR node initialization process. The main change is a correction to the service name used when waiting for the API container to be ready.

Container startup fix:

* Updated the call to `wait_for_container` in `node_cli/operations/fair.py` to use the correct service name (`api` instead of `fair-api`) from `BASE_PASSIVE_FAIR_COMPOSE_SERVICES`.