### PR TITLE
Fix skaled container name in docker utils

### DIFF
--- a/node_cli/utils/docker_utils.py
+++ b/node_cli/utils/docker_utils.py
@@ -120,7 +120,7 @@ def get_containers(container_name_filter=None, _all=True) -> list:
 
 
 def get_all_schain_containers(_all=True) -> list:
-    return docker_client().containers.list(all=_all, filters={'name': 'sk_schain_*'})
+    return docker_client().containers.list(all=_all, filters={'name': 'sk_skaled_*'})
 
 
 def get_all_ima_containers(_all=True) -> list:
@@ -203,7 +203,7 @@ def start_container_by_name(container_name: str, dclient: Optional[DockerClient]
 def remove_schain_container_by_name(
     schain_name: str, dclient: Optional[DockerClient] = None
 ) -> None:
-    container_name = f'sk_schain_{schain_name}'
+    container_name = f'sk_skaled_{schain_name}'
     remove_container_by_name(container_name, timeout=SCHAIN_REMOVE_TIMEOUT, dclient=dclient)
 
 

--- a/tests/cli/health_test.py
+++ b/tests/cli/health_test.py
@@ -9,7 +9,7 @@ OK_LS_RESPONSE_DATA = {
     'payload': [
         {
             'image': 'skalenetwork/schain:1.46-develop.21',
-            'name': 'sk_schain_shapely-alfecca-meridiana',
+            'name': 'sk_skaled_shapely-alfecca-meridiana',
             'state': {
                 'Status': 'running',
                 'Running': True,

--- a/tests/cli/health_test.py
+++ b/tests/cli/health_test.py
@@ -51,7 +51,7 @@ def test_containers():
     assert result.exit_code == 0
     assert (
         result.output
-        == '               Name                   Status         Started At                       Image               \n----------------------------------------------------------------------------------------------------------\nsk_schain_shapely-alfecca-meridiana   Running   Jul 31 2020 11:56:35   skalenetwork/schain:1.46-develop.21\nsk_api                                Running   Jul 31 2020 11:55:17   skale-admin:latest                 \n'  # noqa
+        == '               Name                   Status         Started At                       Image               \n----------------------------------------------------------------------------------------------------------\nsk_skaled_shapely-alfecca-meridiana   Running   Jul 31 2020 11:56:35   skalenetwork/schain:1.46-develop.21\nsk_api                                Running   Jul 31 2020 11:55:17   skale-admin:latest                 \n'  # noqa
     )
 
 


### PR DESCRIPTION
This pull request updates the naming convention for Schain-related Docker containers throughout the codebase. The changes ensure consistency by replacing the old prefix with the new one in both the utility functions and tests.

**Container naming convention update:**

* Changed the filter in `get_all_schain_containers` in `node_cli/utils/docker_utils.py` to search for containers with names starting with `sk_skaled_` instead of `sk_schain_`.
* Updated the container name construction in `remove_schain_container_by_name` in `node_cli/utils/docker_utils.py` to use the `sk_skaled_` prefix.

**Test update:**

* Modified the expected container name in `tests/cli/health_test.py` to use the new `sk_skaled_` prefix.