### PR TITLE
Add FAIR node `turn-on` and `turn-off` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,6 +828,35 @@ Options:
 * `--yes` - Update without confirmation prompt.
 * `--force-skaled-start` - Force skaled container to start (hidden option).
 
+#### Fair Node turn-off
+
+Turn off the Fair node containers.
+
+```shell
+fair node turn-off [--yes]
+```
+
+Options:
+
+* `--yes` - Turn off without confirmation.
+
+#### Fair Node turn-on
+
+Turn on the Fair node containers.
+
+```shell
+fair node turn-on [ENV_FILEPATH] [--yes]
+```
+
+Arguments:
+
+* `ENV_FILEPATH` - Path to the .env file.
+
+Options:
+
+* `--yes` - Turn on without additional confirmation.
+
+
 #### Fair Node Migrate
 
 Switch from boot phase to regular Fair node operation.
@@ -1182,6 +1211,35 @@ Update software / configs for passive Fair node.
 ```shell
 fair passive-node update <ENV_FILEPATH> [--yes]
 ```
+
+#### Passive Fair Node turn-off
+
+Turn off the Fair passive node containers.
+
+```shell
+fair passive-node turn-off [--yes]
+```
+
+Options:
+
+* `--yes` - Turn off without confirmation.
+
+#### Passive Fair Node turn-on
+
+Turn on the Fair passive node containers.
+
+```shell
+fair passive-node turn-on [ENV_FILEPATH] [--yes]
+```
+
+Arguments:
+
+* `ENV_FILEPATH` - Path to the .env file.
+
+Options:
+
+* `--yes` - Turn on without additional confirmation.
+
 
 #### Passive Fair Node Cleanup
 

--- a/node_cli/cli/fair_node.py
+++ b/node_cli/cli/fair_node.py
@@ -212,7 +212,7 @@ def set_domain_name(domain):
     prompt='Are you sure you want to turn off the node?',
 )
 @streamed_cmd
-def _turn_off():
+def turn_off_node() -> None:
     turn_off_fair(node_type=TYPE)
 
 
@@ -224,7 +224,7 @@ def _turn_off():
     expose_value=False,
     prompt='Are you sure you want to turn on the node?',
 )
-@click.argument('env_file')
+@click.argument('env_filepath')
 @streamed_cmd
-def _turn_on(env_file):
-    turn_on_fair(env_file, node_type=TYPE)
+def turn_on_node(env_filepath: str) -> None:
+    turn_on_fair(env_file=env_filepath, node_type=TYPE)

--- a/node_cli/cli/fair_node.py
+++ b/node_cli/cli/fair_node.py
@@ -18,11 +18,13 @@
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import click
-
+from node_cli.cli.info import TYPE
 from node_cli.core.node import backup
 
 from node_cli.fair.active import change_ip as change_ip_fair
 from node_cli.fair.common import cleanup as cleanup_fair
+from node_cli.fair.common import turn_off as turn_off_fair
+from node_cli.fair.common import turn_on as turn_on_fair
 from node_cli.fair.active import exit as exit_fair
 from node_cli.fair.active import (
     get_node_info,
@@ -199,3 +201,30 @@ def exit_node() -> None:
 @streamed_cmd
 def set_domain_name(domain):
     set_domain_name_fair(domain)
+
+
+@node.command('turn-off', help='Turn off the node')
+@click.option(
+    '--yes',
+    is_flag=True,
+    callback=abort_if_false,
+    expose_value=False,
+    prompt='Are you sure you want to turn off the node?',
+)
+@streamed_cmd
+def _turn_off():
+    turn_off_fair(node_type=TYPE)
+
+
+@node.command('turn-on', help='Turn on the node')
+@click.option(
+    '--yes',
+    is_flag=True,
+    callback=abort_if_false,
+    expose_value=False,
+    prompt='Are you sure you want to turn on the node?',
+)
+@click.argument('env_file')
+@streamed_cmd
+def _turn_on(env_file):
+    turn_on_fair(env_file, node_type=TYPE)

--- a/node_cli/cli/fair_node.py
+++ b/node_cli/cli/fair_node.py
@@ -18,25 +18,21 @@
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import click
+
 from node_cli.cli.info import TYPE
 from node_cli.core.node import backup
-
 from node_cli.fair.active import change_ip as change_ip_fair
+from node_cli.fair.active import exit as exit_fair
+from node_cli.fair.active import get_node_info, migrate_from_boot
+from node_cli.fair.active import register as register_fair
+from node_cli.fair.active import restore as restore_fair
+from node_cli.fair.active import set_domain_name as set_domain_name_fair
 from node_cli.fair.common import cleanup as cleanup_fair
+from node_cli.fair.common import init as init_fair
+from node_cli.fair.common import repair_chain
 from node_cli.fair.common import turn_off as turn_off_fair
 from node_cli.fair.common import turn_on as turn_on_fair
-from node_cli.fair.active import exit as exit_fair
-from node_cli.fair.active import (
-    get_node_info,
-    migrate_from_boot,
-    restore as restore_fair,
-)
-from node_cli.fair.common import init as init_fair
-from node_cli.fair.active import register as register_fair
 from node_cli.fair.common import update as update_fair
-from node_cli.fair.active import set_domain_name as set_domain_name_fair
-from node_cli.fair.common import repair_chain
-
 from node_cli.utils.helper import IP_TYPE, URL_OR_ANY_TYPE, abort_if_false, streamed_cmd
 from node_cli.utils.node_type import NodeMode
 from node_cli.utils.texts import safe_load_texts

--- a/node_cli/cli/passive_fair_node.py
+++ b/node_cli/cli/passive_fair_node.py
@@ -19,12 +19,12 @@
 
 import click
 
-from node_cli.fair.common import init as init_fair
-from node_cli.fair.common import update as update_fair
+from node_cli.cli.info import TYPE
 from node_cli.fair.common import cleanup as cleanup_fair
+from node_cli.fair.common import init as init_fair
 from node_cli.fair.common import turn_off as turn_off_fair
 from node_cli.fair.common import turn_on as turn_on_fair
-from node_cli.cli.info import TYPE
+from node_cli.fair.common import update as update_fair
 from node_cli.fair.passive import setup_fair_passive
 from node_cli.utils.helper import (
     URL_OR_ANY_TYPE,

--- a/node_cli/cli/passive_fair_node.py
+++ b/node_cli/cli/passive_fair_node.py
@@ -22,6 +22,9 @@ import click
 from node_cli.fair.common import init as init_fair
 from node_cli.fair.common import update as update_fair
 from node_cli.fair.common import cleanup as cleanup_fair
+from node_cli.fair.common import turn_off as turn_off_fair
+from node_cli.fair.common import turn_on as turn_on_fair
+from node_cli.cli.info import TYPE
 from node_cli.fair.passive import setup_fair_passive
 from node_cli.utils.helper import (
     URL_OR_ANY_TYPE,
@@ -119,3 +122,30 @@ def cleanup_node():
 @click.option('--id', required=True, type=int, help=TEXTS['fair']['node']['setup']['id'])
 def _setup(id: int) -> None:
     setup_fair_passive(node_id=id)
+
+
+@passive_node.command('turn-off', help='Turn off the node')
+@click.option(
+    '--yes',
+    is_flag=True,
+    callback=abort_if_false,
+    expose_value=False,
+    prompt='Are you sure you want to turn off the node?',
+)
+@streamed_cmd
+def turn_off_node() -> None:
+    turn_off_fair(node_type=TYPE)
+
+
+@passive_node.command('turn-on', help='Turn on the node')
+@click.option(
+    '--yes',
+    is_flag=True,
+    callback=abort_if_false,
+    expose_value=False,
+    prompt='Are you sure you want to turn on the node?',
+)
+@click.argument('env_filepath')
+@streamed_cmd
+def turn_on_node(env_filepath: str) -> None:
+    turn_on_fair(env_file=env_filepath, node_type=TYPE)

--- a/node_cli/fair/common.py
+++ b/node_cli/fair/common.py
@@ -17,31 +17,31 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import time
 import logging
+import time
 
 from node_cli.configs import INIT_TIMEOUT, SKALE_DIR, TM_INIT_TIMEOUT
 from node_cli.configs.user import SKALE_DIR_ENV_FILEPATH
 from node_cli.core.docker_config import cleanup_docker_configuration
+from node_cli.core.host import save_env_params
 from node_cli.core.node import compose_node_env, is_base_containers_alive
 from node_cli.core.node_options import upsert_node_mode
 from node_cli.fair.passive import setup_fair_passive
 from node_cli.operations import (
     FairUpdateType,
     cleanup_fair_op,
-    repair_fair_op,
-    update_fair_op,
     init_fair_op,
+    repair_fair_op,
     turn_off_op,
-    turn_on_op
+    turn_on_op,
+    update_fair_op,
 )
-from node_cli.core.host import save_env_params
 from node_cli.utils.decorators import check_inited, check_not_inited, check_user
+from node_cli.utils.exit_codes import CLIExitCodes
+from node_cli.utils.helper import error_exit
 from node_cli.utils.node_type import NodeMode, NodeType
 from node_cli.utils.print_formatters import print_node_cmd_error
 from node_cli.utils.texts import safe_load_texts
-from node_cli.utils.exit_codes import CLIExitCodes
-from node_cli.utils.helper import error_exit
 
 logger = logging.getLogger(__name__)
 TEXTS = safe_load_texts()

--- a/node_cli/fair/common.py
+++ b/node_cli/fair/common.py
@@ -150,12 +150,11 @@ def turn_off(node_type: NodeType) -> None:
 
 @check_inited
 @check_user
-def turn_on(sync_schains, env_file, node_type: NodeType) -> None:
+def turn_on(env_file, node_type: NodeType) -> None:
     node_mode = upsert_node_mode()
     env = compose_node_env(
         env_file,
         inited_node=True,
-        sync_schains=sync_schains,
         node_type=node_type,
         node_mode=node_mode,
     )

--- a/node_cli/fair/common.py
+++ b/node_cli/fair/common.py
@@ -20,7 +20,7 @@
 import time
 import logging
 
-from node_cli.configs import INIT_TIMEOUT, SKALE_DIR
+from node_cli.configs import INIT_TIMEOUT, SKALE_DIR, TM_INIT_TIMEOUT
 from node_cli.configs.user import SKALE_DIR_ENV_FILEPATH
 from node_cli.core.docker_config import cleanup_docker_configuration
 from node_cli.core.node import compose_node_env, is_base_containers_alive
@@ -32,6 +32,8 @@ from node_cli.operations import (
     repair_fair_op,
     update_fair_op,
     init_fair_op,
+    turn_off_op,
+    turn_on_op
 )
 from node_cli.core.host import save_env_params
 from node_cli.utils.decorators import check_inited, check_not_inited, check_user
@@ -134,3 +136,33 @@ def repair_chain(snapshot_from: str = 'any') -> None:
         SKALE_DIR_ENV_FILEPATH, save=False, node_type=NodeType.FAIR, node_mode=node_mode
     )
     repair_fair_op(env=env, snapshot_from=snapshot_from)
+
+
+@check_inited
+@check_user
+def turn_off(node_type: NodeType) -> None:
+    node_mode = upsert_node_mode()
+    env = compose_node_env(
+        SKALE_DIR_ENV_FILEPATH, save=False, node_type=node_type, node_mode=node_mode
+    )
+    turn_off_op(node_type=node_type, node_mode=node_mode, env=env)
+
+
+@check_inited
+@check_user
+def turn_on(sync_schains, env_file, node_type: NodeType) -> None:
+    node_mode = upsert_node_mode()
+    env = compose_node_env(
+        env_file,
+        inited_node=True,
+        sync_schains=sync_schains,
+        node_type=node_type,
+        node_mode=node_mode,
+    )
+    turn_on_op(env=env, node_type=node_type, node_mode=node_mode)
+    logger.info('Waiting for containers initialization')
+    time.sleep(TM_INIT_TIMEOUT)
+    if not is_base_containers_alive(node_type=node_type, node_mode=node_mode):
+        print_node_cmd_error()
+        return
+    logger.info('Node turned on')

--- a/node_cli/operations/base.py
+++ b/node_cli/operations/base.py
@@ -359,14 +359,23 @@ def turn_off(env: dict, node_type: NodeType, node_mode: NodeMode) -> None:
 
 def turn_on(env: dict, node_type: NodeType, node_mode: NodeMode) -> None:
     logger.info('Turning on the node...')
-    meta_manager = CliMetaManager()
-    meta_manager.update_meta(
-        VERSION,
-        env['NODE_VERSION'],
-        env['DOCKER_LVMPY_VERSION'],
-        distro.id(),
-        distro.version(),
-    )
+    if node_type == NodeType.FAIR:
+        meta_manager = FairCliMetaManager()
+        meta_manager.update_meta(
+            VERSION,
+            env['NODE_VERSION'],
+            distro.id(),
+            distro.version(),
+        )
+    else:
+        meta_manager = CliMetaManager()
+        meta_manager.update_meta(
+            VERSION,
+            env['NODE_VERSION'],
+            env['DOCKER_LVMPY_VERSION'],
+            distro.id(),
+            distro.version()
+        )
     if env.get('SKIP_DOCKER_CONFIG') != 'True':
         configure_docker()
 


### PR DESCRIPTION
This pull request adds new CLI commands for turning Fair node and passive Fair node containers on and off, along with updates to documentation and supporting logic. The changes introduce `turn-on` and `turn-off` commands for both node types, allowing users to manage node container states directly from the CLI, with confirmation prompts and `.env` file support. Documentation in `README.md` has been updated to reflect these new commands, and the underlying implementation ensures proper initialization and error handling.

**New CLI commands and logic for node management:**

* Added `turn-off` and `turn-on` commands to both `fair_node.py` and `passive_fair_node.py`, enabling users to start and stop Fair node and passive Fair node containers from the CLI, with confirmation prompts and `.env` file handling. [[1]](diffhunk://#diff-2f82f30c374ab8a51e09163549a12b05544deb7793f40e09c028aa2457d91364R200-R226) [[2]](diffhunk://#diff-4c709cc566179479c162f75ac17db239204e4366e95e49237797e1c3096bf25dR125-R151)
* Implemented supporting functions `turn_off` and `turn_on` in `fair/common.py`, which handle environment setup, container state changes, and initialization waits for Fair nodes.

**Documentation updates:**

* Updated `README.md` to document the new `turn-on` and `turn-off` commands for both Fair node and passive Fair node, including usage examples, arguments, and options. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R831-R859) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1215-R1243)

**Internal logic and dependency improvements:**

* Refactored imports and internal function calls in CLI modules to support new commands and improve code organization. [[1]](diffhunk://#diff-2f82f30c374ab8a51e09163549a12b05544deb7793f40e09c028aa2457d91364R22-R35) [[2]](diffhunk://#diff-4c709cc566179479c162f75ac17db239204e4366e95e49237797e1c3096bf25dR22-L24)
* Enhanced metadata update logic in `operations/base.py` to properly handle Fair node type during the turn-on operation.