### PR TITLE
Fix nginx container name

### DIFF
--- a/node_cli/configs/__init__.py
+++ b/node_cli/configs/__init__.py
@@ -62,7 +62,7 @@ FAIR_STATIC_PARAMS_FILEPATH = os.path.join(CONTAINER_CONFIG_PATH, 'fair_static_p
 
 NGINX_TEMPLATE_FILEPATH = os.path.join(CONTAINER_CONFIG_PATH, 'nginx.conf.j2')
 NGINX_CONFIG_FILEPATH = os.path.join(NODE_DATA_PATH, 'nginx.conf')
-NGINX_CONTAINER_NAME = 'skale_nginx'
+NGINX_CONTAINER_NAME = 'sk_nginx'
 
 LOG_PATH = os.path.join(NODE_DATA_PATH, 'log')
 REMOVED_CONTAINERS_FOLDER_NAME = '.removed_containers'


### PR DESCRIPTION
This pull request makes a minor update to the `NGINX_CONTAINER_NAME` constant in the `node_cli/configs/__init__.py` file, changing its value to better reflect the container naming convention.

* Renamed the `NGINX_CONTAINER_NAME` constant from `'skale_nginx'` to `'sk_nginx'` in `node_cli/configs/__init__.py`.