### PR TITLE
Update staking functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1098,13 +1098,56 @@ Arguments:
 
 * `RECEIVER_ADDRESS` - Address to remove from the allowed receivers list.
 
-#### Claim fees
+Workflow (fees): request fees -> review exit requests -> claim request.
 
-Claim a specific amount of fees or all fees to the node wallet.
+#### Request fees
+
+Create a request to claim a specific amount of earned fees (FAIR). Use `--all` to request all.
 
 ```shell
-fair staking claim-fees <AMOUNT>
-fair staking claim-fees --all
+fair staking request-fees <AMOUNT>
+fair staking request-fees --all
+```
+
+#### Request send fees
+
+Create a request to send a specific amount (or all) of earned fees to an address.
+
+```shell
+fair staking request-send-fees <TO_ADDRESS> <AMOUNT>
+fair staking request-send-fees <TO_ADDRESS> --all
+```
+
+Arguments:
+
+* `TO_ADDRESS` - Destination address for the fee transfer.
+* `AMOUNT` - Amount of fees to include in the request (FAIR).
+
+#### Claim request
+
+Claim a previously created request by its request ID once it is unlocked.
+
+```shell
+fair staking claim-request <REQUEST_ID>
+```
+
+#### Get exit requests
+
+List exit (fee withdrawal) requests for the current wallet. Use `--json` for raw JSON output.
+
+```shell
+fair staking exit-requests
+fair staking exit-requests --json
+```
+
+Default output (non-JSON) shows: `request_id`, `user`, `node_id`, `amount_wei`, `amount_fair`, `unlock_date (ISO)`.
+
+#### Get earned fee amount
+
+Get the currently earned (unrequested) fee amount.
+
+```shell
+fair staking earned-fee-amount
 ```
 
 #### Set fee rate
@@ -1118,27 +1161,6 @@ fair staking set-fee-rate <FEE_RATE>
 Arguments:
 
 * `FEE_RATE` - Fee rate value as integer (uint16).
-
-#### Send fees
-
-Send a specific amount of fees to the default allowed receiver.
-
-```shell
-fair staking send-fees <TO_ADDRESS> <AMOUNT>
-```
-
-Arguments:
-
-* `TO_ADDRESS` - Destination address for the fee transfer.
-* `AMOUNT` - Amount of fees to send (FAIR). Use `--all` to send all.
-
-#### Get earned fee amount
-
-Get the currently earned fee amount.
-
-```shell
-fair staking get-earned-fee-amount
-```
 
 ### Passive Fair Node commands
 

--- a/node_cli/cli/staking.py
+++ b/node_cli/cli/staking.py
@@ -23,9 +23,11 @@ from node_cli.fair.staking import (
     add_allowed_receiver,
     remove_allowed_receiver,
     set_fee_rate,
-    claim_fees,
-    send_fees,
+    request_fees,
+    request_send_fees,
+    claim_request,
     get_earned_fee_amount,
+    get_exit_requests,
 )
 from node_cli.utils.helper import abort_if_false
 
@@ -79,39 +81,61 @@ def _set_fee_rate(fee_rate: int) -> None:
     set_fee_rate(fee_rate)
 
 
-@staking.command('claim-fees', help='Claim fees amount (FAIR) or all with --all')
+@staking.command('request-fees', help='Create a request to claim fees (FAIR) or all with --all')
 @click.argument('amount', type=float, required=False)
-@click.option('--all', 'claim_all', is_flag=True, help='Claim all fees')
+@click.option('--all', 'request_all', is_flag=True, help='Request all fees')
 @click.option(
     '--yes',
     is_flag=True,
     callback=abort_if_false,
     expose_value=False,
-    prompt='Are you sure you want to claim fees?',
+    prompt='Are you sure you want to request fees?',
 )
-def _claim_fees(amount: float | None, claim_all: bool) -> None:
-    if amount is None and not claim_all:
+def _request_fees(amount: float | None, request_all: bool) -> None:
+    if amount is None and not request_all:
         raise click.UsageError('Provide <AMOUNT> or use --all')
-    claim_fees(None if claim_all else amount)
+    request_fees(None if request_all else amount)
 
 
-@staking.command('send-fees', help='Send fees to address (or all with --all)')
+@staking.command(
+    'request-send-fees',
+    help='Create a request to send fees to address (or all with --all)',
+)
 @click.argument('to')
 @click.argument('amount', type=float, required=False)
-@click.option('--all', 'send_all', is_flag=True, help='Send all fees to address')
+@click.option('--all', 'send_all', is_flag=True, help='Request to send all fees to address')
 @click.option(
     '--yes',
     is_flag=True,
     callback=abort_if_false,
     expose_value=False,
-    prompt='Are you sure you want to send fees?',
+    prompt='Are you sure you want to request to send fees?',
 )
-def _send_fees(to: str, amount: float | None, send_all: bool) -> None:
+def _request_send_fees(to: str, amount: float | None, send_all: bool) -> None:
     if amount is None and not send_all:
         raise click.UsageError('Provide <AMOUNT> or use --all')
-    send_fees(to, None if send_all else amount)
+    request_send_fees(to, None if send_all else amount)
 
 
-@staking.command('get-earned-fee-amount', help='Get earned fee amount')
+@staking.command('claim-request', help='Claim previously created request by request ID')
+@click.argument('request_id', type=int)
+@click.option(
+    '--yes',
+    is_flag=True,
+    callback=abort_if_false,
+    expose_value=False,
+    prompt='Are you sure you want to claim this request?',
+)
+def _claim_request(request_id: int) -> None:
+    claim_request(request_id)
+
+
+@staking.command('earned-fee-amount', help='Get earned fee amount')
 def _get_earned_fee_amount() -> None:
     get_earned_fee_amount()
+
+
+@staking.command('exit-requests', help='Get exit requests for current wallet')
+@click.option('--json', 'raw', is_flag=True, help='Output in JSON format')
+def _get_exit_requests(raw: bool) -> None:
+    get_exit_requests(raw=raw)

--- a/node_cli/configs/routes.py
+++ b/node_cli/configs/routes.py
@@ -47,9 +47,11 @@ ROUTES = {
             'add-receiver',
             'remove-receiver',
             'set-fee-rate',
-            'claim-fees',
-            'send-fees',
+            'request-fees',
+            'request-send-fees',
+            'claim-request',
             'get-earned-fee-amount',
+            'get-exit-requests',
         ],
     }
 }

--- a/node_cli/fair/staking.py
+++ b/node_cli/fair/staking.py
@@ -18,6 +18,8 @@
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from typing import Any
+import json
+from datetime import datetime, timezone
 
 from node_cli.utils.decorators import check_inited
 from node_cli.utils.exit_codes import CLIExitCodes
@@ -50,12 +52,27 @@ def remove_allowed_receiver(receiver: str) -> None:
 
 
 @check_inited
-def send_fees(to: str, amount: float | None) -> None:
+def request_fees(amount: float | None) -> None:
+    json_data: dict[str, Any] = {}
+    if amount is not None:
+        json_data['amount'] = amount
+    status, payload = post_request(blueprint=BLUEPRINT_NAME, method='request-fees', json=json_data)
+    _handle_response(
+        status,
+        payload,
+        success='All fees requested' if amount is None else f'Fees requested: {amount}',
+    )
+
+
+@check_inited
+def request_send_fees(to: str, amount: float | None) -> None:
     json_data: dict[str, Any] = {'to': to}
     if amount is not None:
         json_data['amount'] = amount
-    status, payload = post_request(blueprint=BLUEPRINT_NAME, method='send-fees', json=json_data)
-    _handle_response(status, payload, success=f'Fees sent to {to}')
+    status, payload = post_request(
+        blueprint=BLUEPRINT_NAME, method='request-send-fees', json=json_data
+    )
+    _handle_response(status, payload, success=f'Fees request to send to {to} created')
 
 
 @check_inited
@@ -67,16 +84,11 @@ def set_fee_rate(fee_rate: int) -> None:
 
 
 @check_inited
-def claim_fees(amount: float | None) -> None:
-    json_data: dict[str, Any] = {}
-    if amount is not None:
-        json_data['amount'] = amount
-    status, payload = post_request(blueprint=BLUEPRINT_NAME, method='claim-fees', json=json_data)
-    _handle_response(
-        status,
-        payload,
-        success='All fees claimed' if amount is None else f'Fees claimed: {amount}',
+def claim_request(request_id: int) -> None:
+    status, payload = post_request(
+        blueprint=BLUEPRINT_NAME, method='claim-request', json={'requestId': request_id}
     )
+    _handle_response(status, payload, success=f'Request claimed: {request_id}')
 
 
 @check_inited
@@ -86,5 +98,41 @@ def get_earned_fee_amount() -> None:
         amount_wei = payload.get('amount_wei')
         amount_ether = payload.get('amount_ether')
         print(f'Earned fee amount: {amount_wei} wei ({amount_ether} FAIR)')
+        return
+    error_exit(payload, exit_code=CLIExitCodes.BAD_API_RESPONSE)
+
+
+@check_inited
+def get_exit_requests(raw: bool = False) -> None:
+    status, payload = post_request(blueprint=BLUEPRINT_NAME, method='get-exit-requests')
+    if status == 'ok' and isinstance(payload, dict):
+        exit_requests = payload.get('exit_requests')
+        if not isinstance(exit_requests, list):
+            error_exit(payload, exit_code=CLIExitCodes.BAD_API_RESPONSE)
+            return
+        if raw:
+            print(json.dumps(exit_requests, indent=2))
+            return
+        for req in exit_requests:
+            try:
+                request_id = req.get('request_id')
+                user = req.get('user')
+                node_id = req.get('node_id')
+                amount = req.get('amount')
+                unlock_date = req.get('unlock_date')
+                amount_fair = None
+                if isinstance(amount, int):
+                    amount_fair = amount / 10**18
+                unlock_iso = None
+                if isinstance(unlock_date, int):
+                    unlock_iso = datetime.fromtimestamp(unlock_date, tz=timezone.utc).isoformat()
+                base = (
+                    f'request_id: {request_id} | user: {user} | node_id: {node_id} | '
+                    f'amount_wei: {amount} | amount_fair: {amount_fair} | '
+                    f'unlock_date: {unlock_date}'
+                )
+                print(base + (f' ({unlock_iso})' if unlock_iso else ''))
+            except Exception:  # noqa: BLE001
+                print(req)
         return
     error_exit(payload, exit_code=CLIExitCodes.BAD_API_RESPONSE)

--- a/tests/routes_test.py
+++ b/tests/routes_test.py
@@ -42,9 +42,11 @@ ALL_V1_ROUTES = [
     '/api/v1/fair-staking/add-receiver',
     '/api/v1/fair-staking/remove-receiver',
     '/api/v1/fair-staking/set-fee-rate',
-    '/api/v1/fair-staking/claim-fees',
-    '/api/v1/fair-staking/send-fees',
+    '/api/v1/fair-staking/request-fees',
+    '/api/v1/fair-staking/request-send-fees',
+    '/api/v1/fair-staking/claim-request',
     '/api/v1/fair-staking/get-earned-fee-amount',
+    '/api/v1/fair-staking/get-exit-requests',
 ]
 
 


### PR DESCRIPTION
This pull request refactors the staking fee withdrawal workflow to use a request-based system instead of direct claims and sends. The CLI commands and backend logic have been updated to support creating withdrawal requests, claiming them after review/unlock, and listing exit requests. Documentation and tests have also been updated to reflect these changes.

**Fee withdrawal workflow changes:**

* Replaced direct `claim-fees` and `send-fees` commands with `request-fees` and `request-send-fees`, which create withdrawal requests instead of immediately transferring fees. Added a new `claim-request` command to claim a previously created request by its ID. [[1]](diffhunk://#diff-02de47bd3a465d6a447238abc4ee25d7e7ca504652573d0245ab90e69762eecaL82-R141) [[2]](diffhunk://#diff-ccb3ed613dd4c625ea28296a22663912195d784659d62dd5c5222d153fb81310L53-R75) [[3]](diffhunk://#diff-ccb3ed613dd4c625ea28296a22663912195d784659d62dd5c5222d153fb81310L70-R91) [[4]](diffhunk://#diff-12132dde0bdef91d2276291fd892108242ea0254c453d6829b544adc06a76b40L50-R54)
* Added backend functions `request_fees`, `request_send_fees`, and `claim_request` in `node_cli/fair/staking.py` to implement the new request-based workflow. [[1]](diffhunk://#diff-ccb3ed613dd4c625ea28296a22663912195d784659d62dd5c5222d153fb81310L53-R75) [[2]](diffhunk://#diff-ccb3ed613dd4c625ea28296a22663912195d784659d62dd5c5222d153fb81310L70-R91)

**Exit requests listing:**

* Introduced a new `exit-requests` CLI command and corresponding backend function to list exit requests for the current wallet, with support for JSON output and formatted summaries. [[1]](diffhunk://#diff-02de47bd3a465d6a447238abc4ee25d7e7ca504652573d0245ab90e69762eecaL82-R141) [[2]](diffhunk://#diff-ccb3ed613dd4c625ea28296a22663912195d784659d62dd5c5222d153fb81310R103-R138)

**Documentation updates:**

* Updated `README.md` to describe the new workflow, CLI commands, and arguments for fee withdrawal requests, claims, and exit requests.

**API and route changes:**

* Updated API routes and tests to match the new request-based endpoints (`request-fees`, `request-send-fees`, `claim-request`, `get-exit-requests`). [[1]](diffhunk://#diff-12132dde0bdef91d2276291fd892108242ea0254c453d6829b544adc06a76b40L50-R54) [[2]](diffhunk://#diff-d81e73c3c932063b87df06ac64485eb6e3a636abd58caf1b9ac62702ffcbd2faL45-R49)

These changes improve the security and auditability of fee withdrawals by introducing a multi-step request and claim process.