### PR TITLE
Fair to fair beta 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1098,13 +1098,56 @@ Arguments:
 
 * `RECEIVER_ADDRESS` - Address to remove from the allowed receivers list.
 
-#### Claim fees
+Workflow (fees): request fees -> review exit requests -> claim request.
 
-Claim a specific amount of fees or all fees to the node wallet.
+#### Request fees
+
+Create a request to claim a specific amount of earned fees (FAIR). Use `--all` to request all.
 
 ```shell
-fair staking claim-fees <AMOUNT>
-fair staking claim-fees --all
+fair staking request-fees <AMOUNT>
+fair staking request-fees --all
+```
+
+#### Request send fees
+
+Create a request to send a specific amount (or all) of earned fees to an address.
+
+```shell
+fair staking request-send-fees <TO_ADDRESS> <AMOUNT>
+fair staking request-send-fees <TO_ADDRESS> --all
+```
+
+Arguments:
+
+* `TO_ADDRESS` - Destination address for the fee transfer.
+* `AMOUNT` - Amount of fees to include in the request (FAIR).
+
+#### Claim request
+
+Claim a previously created request by its request ID once it is unlocked.
+
+```shell
+fair staking claim-request <REQUEST_ID>
+```
+
+#### Get exit requests
+
+List exit (fee withdrawal) requests for the current wallet. Use `--json` for raw JSON output.
+
+```shell
+fair staking exit-requests
+fair staking exit-requests --json
+```
+
+Default output (non-JSON) shows: `request_id`, `user`, `node_id`, `amount_wei`, `amount_fair`, `unlock_date (ISO)`.
+
+#### Get earned fee amount
+
+Get the currently earned (unrequested) fee amount.
+
+```shell
+fair staking earned-fee-amount
 ```
 
 #### Set fee rate
@@ -1118,27 +1161,6 @@ fair staking set-fee-rate <FEE_RATE>
 Arguments:
 
 * `FEE_RATE` - Fee rate value as integer (uint16).
-
-#### Send fees
-
-Send a specific amount of fees to the default allowed receiver.
-
-```shell
-fair staking send-fees <TO_ADDRESS> <AMOUNT>
-```
-
-Arguments:
-
-* `TO_ADDRESS` - Destination address for the fee transfer.
-* `AMOUNT` - Amount of fees to send (FAIR). Use `--all` to send all.
-
-#### Get earned fee amount
-
-Get the currently earned fee amount.
-
-```shell
-fair staking get-earned-fee-amount
-```
 
 ### Passive Fair Node commands
 

--- a/README.md
+++ b/README.md
@@ -828,6 +828,35 @@ Options:
 * `--yes` - Update without confirmation prompt.
 * `--force-skaled-start` - Force skaled container to start (hidden option).
 
+#### Fair Node turn-off
+
+Turn off the Fair node containers.
+
+```shell
+fair node turn-off [--yes]
+```
+
+Options:
+
+* `--yes` - Turn off without confirmation.
+
+#### Fair Node turn-on
+
+Turn on the Fair node containers.
+
+```shell
+fair node turn-on [ENV_FILEPATH] [--yes]
+```
+
+Arguments:
+
+* `ENV_FILEPATH` - Path to the .env file.
+
+Options:
+
+* `--yes` - Turn on without additional confirmation.
+
+
 #### Fair Node Migrate
 
 Switch from boot phase to regular Fair node operation.
@@ -1182,6 +1211,35 @@ Update software / configs for passive Fair node.
 ```shell
 fair passive-node update <ENV_FILEPATH> [--yes]
 ```
+
+#### Passive Fair Node turn-off
+
+Turn off the Fair passive node containers.
+
+```shell
+fair passive-node turn-off [--yes]
+```
+
+Options:
+
+* `--yes` - Turn off without confirmation.
+
+#### Passive Fair Node turn-on
+
+Turn on the Fair passive node containers.
+
+```shell
+fair passive-node turn-on [ENV_FILEPATH] [--yes]
+```
+
+Arguments:
+
+* `ENV_FILEPATH` - Path to the .env file.
+
+Options:
+
+* `--yes` - Turn on without additional confirmation.
+
 
 #### Passive Fair Node Cleanup
 

--- a/node_cli/cli/fair_node.py
+++ b/node_cli/cli/fair_node.py
@@ -212,7 +212,7 @@ def set_domain_name(domain):
     prompt='Are you sure you want to turn off the node?',
 )
 @streamed_cmd
-def _turn_off():
+def turn_off_node() -> None:
     turn_off_fair(node_type=TYPE)
 
 
@@ -224,7 +224,7 @@ def _turn_off():
     expose_value=False,
     prompt='Are you sure you want to turn on the node?',
 )
-@click.argument('env_file')
+@click.argument('env_filepath')
 @streamed_cmd
-def _turn_on(env_file):
-    turn_on_fair(env_file, node_type=TYPE)
+def turn_on_node(env_filepath: str) -> None:
+    turn_on_fair(env_file=env_filepath, node_type=TYPE)

--- a/node_cli/cli/fair_node.py
+++ b/node_cli/cli/fair_node.py
@@ -18,11 +18,13 @@
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import click
-
+from node_cli.cli.info import TYPE
 from node_cli.core.node import backup
 
 from node_cli.fair.active import change_ip as change_ip_fair
 from node_cli.fair.common import cleanup as cleanup_fair
+from node_cli.fair.common import turn_off as turn_off_fair
+from node_cli.fair.common import turn_on as turn_on_fair
 from node_cli.fair.active import exit as exit_fair
 from node_cli.fair.active import (
     get_node_info,
@@ -199,3 +201,30 @@ def exit_node() -> None:
 @streamed_cmd
 def set_domain_name(domain):
     set_domain_name_fair(domain)
+
+
+@node.command('turn-off', help='Turn off the node')
+@click.option(
+    '--yes',
+    is_flag=True,
+    callback=abort_if_false,
+    expose_value=False,
+    prompt='Are you sure you want to turn off the node?',
+)
+@streamed_cmd
+def _turn_off():
+    turn_off_fair(node_type=TYPE)
+
+
+@node.command('turn-on', help='Turn on the node')
+@click.option(
+    '--yes',
+    is_flag=True,
+    callback=abort_if_false,
+    expose_value=False,
+    prompt='Are you sure you want to turn on the node?',
+)
+@click.argument('env_file')
+@streamed_cmd
+def _turn_on(env_file):
+    turn_on_fair(env_file, node_type=TYPE)

--- a/node_cli/cli/fair_node.py
+++ b/node_cli/cli/fair_node.py
@@ -18,25 +18,21 @@
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import click
+
 from node_cli.cli.info import TYPE
 from node_cli.core.node import backup
-
 from node_cli.fair.active import change_ip as change_ip_fair
+from node_cli.fair.active import exit as exit_fair
+from node_cli.fair.active import get_node_info, migrate_from_boot
+from node_cli.fair.active import register as register_fair
+from node_cli.fair.active import restore as restore_fair
+from node_cli.fair.active import set_domain_name as set_domain_name_fair
 from node_cli.fair.common import cleanup as cleanup_fair
+from node_cli.fair.common import init as init_fair
+from node_cli.fair.common import repair_chain
 from node_cli.fair.common import turn_off as turn_off_fair
 from node_cli.fair.common import turn_on as turn_on_fair
-from node_cli.fair.active import exit as exit_fair
-from node_cli.fair.active import (
-    get_node_info,
-    migrate_from_boot,
-    restore as restore_fair,
-)
-from node_cli.fair.common import init as init_fair
-from node_cli.fair.active import register as register_fair
 from node_cli.fair.common import update as update_fair
-from node_cli.fair.active import set_domain_name as set_domain_name_fair
-from node_cli.fair.common import repair_chain
-
 from node_cli.utils.helper import IP_TYPE, URL_OR_ANY_TYPE, abort_if_false, streamed_cmd
 from node_cli.utils.node_type import NodeMode
 from node_cli.utils.texts import safe_load_texts

--- a/node_cli/cli/passive_fair_node.py
+++ b/node_cli/cli/passive_fair_node.py
@@ -19,12 +19,12 @@
 
 import click
 
-from node_cli.fair.common import init as init_fair
-from node_cli.fair.common import update as update_fair
+from node_cli.cli.info import TYPE
 from node_cli.fair.common import cleanup as cleanup_fair
+from node_cli.fair.common import init as init_fair
 from node_cli.fair.common import turn_off as turn_off_fair
 from node_cli.fair.common import turn_on as turn_on_fair
-from node_cli.cli.info import TYPE
+from node_cli.fair.common import update as update_fair
 from node_cli.fair.passive import setup_fair_passive
 from node_cli.utils.helper import (
     URL_OR_ANY_TYPE,

--- a/node_cli/cli/passive_fair_node.py
+++ b/node_cli/cli/passive_fair_node.py
@@ -22,6 +22,9 @@ import click
 from node_cli.fair.common import init as init_fair
 from node_cli.fair.common import update as update_fair
 from node_cli.fair.common import cleanup as cleanup_fair
+from node_cli.fair.common import turn_off as turn_off_fair
+from node_cli.fair.common import turn_on as turn_on_fair
+from node_cli.cli.info import TYPE
 from node_cli.fair.passive import setup_fair_passive
 from node_cli.utils.helper import (
     URL_OR_ANY_TYPE,
@@ -119,3 +122,30 @@ def cleanup_node():
 @click.option('--id', required=True, type=int, help=TEXTS['fair']['node']['setup']['id'])
 def _setup(id: int) -> None:
     setup_fair_passive(node_id=id)
+
+
+@passive_node.command('turn-off', help='Turn off the node')
+@click.option(
+    '--yes',
+    is_flag=True,
+    callback=abort_if_false,
+    expose_value=False,
+    prompt='Are you sure you want to turn off the node?',
+)
+@streamed_cmd
+def turn_off_node() -> None:
+    turn_off_fair(node_type=TYPE)
+
+
+@passive_node.command('turn-on', help='Turn on the node')
+@click.option(
+    '--yes',
+    is_flag=True,
+    callback=abort_if_false,
+    expose_value=False,
+    prompt='Are you sure you want to turn on the node?',
+)
+@click.argument('env_filepath')
+@streamed_cmd
+def turn_on_node(env_filepath: str) -> None:
+    turn_on_fair(env_file=env_filepath, node_type=TYPE)

--- a/node_cli/cli/staking.py
+++ b/node_cli/cli/staking.py
@@ -23,9 +23,11 @@ from node_cli.fair.staking import (
     add_allowed_receiver,
     remove_allowed_receiver,
     set_fee_rate,
-    claim_fees,
-    send_fees,
+    request_fees,
+    request_send_fees,
+    claim_request,
     get_earned_fee_amount,
+    get_exit_requests,
 )
 from node_cli.utils.helper import abort_if_false
 
@@ -79,39 +81,61 @@ def _set_fee_rate(fee_rate: int) -> None:
     set_fee_rate(fee_rate)
 
 
-@staking.command('claim-fees', help='Claim fees amount (FAIR) or all with --all')
+@staking.command('request-fees', help='Create a request to claim fees (FAIR) or all with --all')
 @click.argument('amount', type=float, required=False)
-@click.option('--all', 'claim_all', is_flag=True, help='Claim all fees')
+@click.option('--all', 'request_all', is_flag=True, help='Request all fees')
 @click.option(
     '--yes',
     is_flag=True,
     callback=abort_if_false,
     expose_value=False,
-    prompt='Are you sure you want to claim fees?',
+    prompt='Are you sure you want to request fees?',
 )
-def _claim_fees(amount: float | None, claim_all: bool) -> None:
-    if amount is None and not claim_all:
+def _request_fees(amount: float | None, request_all: bool) -> None:
+    if amount is None and not request_all:
         raise click.UsageError('Provide <AMOUNT> or use --all')
-    claim_fees(None if claim_all else amount)
+    request_fees(None if request_all else amount)
 
 
-@staking.command('send-fees', help='Send fees to address (or all with --all)')
+@staking.command(
+    'request-send-fees',
+    help='Create a request to send fees to address (or all with --all)',
+)
 @click.argument('to')
 @click.argument('amount', type=float, required=False)
-@click.option('--all', 'send_all', is_flag=True, help='Send all fees to address')
+@click.option('--all', 'send_all', is_flag=True, help='Request to send all fees to address')
 @click.option(
     '--yes',
     is_flag=True,
     callback=abort_if_false,
     expose_value=False,
-    prompt='Are you sure you want to send fees?',
+    prompt='Are you sure you want to request to send fees?',
 )
-def _send_fees(to: str, amount: float | None, send_all: bool) -> None:
+def _request_send_fees(to: str, amount: float | None, send_all: bool) -> None:
     if amount is None and not send_all:
         raise click.UsageError('Provide <AMOUNT> or use --all')
-    send_fees(to, None if send_all else amount)
+    request_send_fees(to, None if send_all else amount)
 
 
-@staking.command('get-earned-fee-amount', help='Get earned fee amount')
+@staking.command('claim-request', help='Claim previously created request by request ID')
+@click.argument('request_id', type=int)
+@click.option(
+    '--yes',
+    is_flag=True,
+    callback=abort_if_false,
+    expose_value=False,
+    prompt='Are you sure you want to claim this request?',
+)
+def _claim_request(request_id: int) -> None:
+    claim_request(request_id)
+
+
+@staking.command('earned-fee-amount', help='Get earned fee amount')
 def _get_earned_fee_amount() -> None:
     get_earned_fee_amount()
+
+
+@staking.command('exit-requests', help='Get exit requests for current wallet')
+@click.option('--json', 'raw', is_flag=True, help='Output in JSON format')
+def _get_exit_requests(raw: bool) -> None:
+    get_exit_requests(raw=raw)

--- a/node_cli/configs/routes.py
+++ b/node_cli/configs/routes.py
@@ -47,9 +47,11 @@ ROUTES = {
             'add-receiver',
             'remove-receiver',
             'set-fee-rate',
-            'claim-fees',
-            'send-fees',
+            'request-fees',
+            'request-send-fees',
+            'claim-request',
             'get-earned-fee-amount',
+            'get-exit-requests',
         ],
     }
 }

--- a/node_cli/fair/common.py
+++ b/node_cli/fair/common.py
@@ -17,31 +17,31 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import time
 import logging
+import time
 
 from node_cli.configs import INIT_TIMEOUT, SKALE_DIR, TM_INIT_TIMEOUT
 from node_cli.configs.user import SKALE_DIR_ENV_FILEPATH
 from node_cli.core.docker_config import cleanup_docker_configuration
+from node_cli.core.host import save_env_params
 from node_cli.core.node import compose_node_env, is_base_containers_alive
 from node_cli.core.node_options import upsert_node_mode
 from node_cli.fair.passive import setup_fair_passive
 from node_cli.operations import (
     FairUpdateType,
     cleanup_fair_op,
-    repair_fair_op,
-    update_fair_op,
     init_fair_op,
+    repair_fair_op,
     turn_off_op,
-    turn_on_op
+    turn_on_op,
+    update_fair_op,
 )
-from node_cli.core.host import save_env_params
 from node_cli.utils.decorators import check_inited, check_not_inited, check_user
+from node_cli.utils.exit_codes import CLIExitCodes
+from node_cli.utils.helper import error_exit
 from node_cli.utils.node_type import NodeMode, NodeType
 from node_cli.utils.print_formatters import print_node_cmd_error
 from node_cli.utils.texts import safe_load_texts
-from node_cli.utils.exit_codes import CLIExitCodes
-from node_cli.utils.helper import error_exit
 
 logger = logging.getLogger(__name__)
 TEXTS = safe_load_texts()

--- a/node_cli/fair/common.py
+++ b/node_cli/fair/common.py
@@ -150,12 +150,11 @@ def turn_off(node_type: NodeType) -> None:
 
 @check_inited
 @check_user
-def turn_on(sync_schains, env_file, node_type: NodeType) -> None:
+def turn_on(env_file, node_type: NodeType) -> None:
     node_mode = upsert_node_mode()
     env = compose_node_env(
         env_file,
         inited_node=True,
-        sync_schains=sync_schains,
         node_type=node_type,
         node_mode=node_mode,
     )

--- a/node_cli/fair/common.py
+++ b/node_cli/fair/common.py
@@ -20,7 +20,7 @@
 import time
 import logging
 
-from node_cli.configs import INIT_TIMEOUT, SKALE_DIR
+from node_cli.configs import INIT_TIMEOUT, SKALE_DIR, TM_INIT_TIMEOUT
 from node_cli.configs.user import SKALE_DIR_ENV_FILEPATH
 from node_cli.core.docker_config import cleanup_docker_configuration
 from node_cli.core.node import compose_node_env, is_base_containers_alive
@@ -32,6 +32,8 @@ from node_cli.operations import (
     repair_fair_op,
     update_fair_op,
     init_fair_op,
+    turn_off_op,
+    turn_on_op
 )
 from node_cli.core.host import save_env_params
 from node_cli.utils.decorators import check_inited, check_not_inited, check_user
@@ -134,3 +136,33 @@ def repair_chain(snapshot_from: str = 'any') -> None:
         SKALE_DIR_ENV_FILEPATH, save=False, node_type=NodeType.FAIR, node_mode=node_mode
     )
     repair_fair_op(env=env, snapshot_from=snapshot_from)
+
+
+@check_inited
+@check_user
+def turn_off(node_type: NodeType) -> None:
+    node_mode = upsert_node_mode()
+    env = compose_node_env(
+        SKALE_DIR_ENV_FILEPATH, save=False, node_type=node_type, node_mode=node_mode
+    )
+    turn_off_op(node_type=node_type, node_mode=node_mode, env=env)
+
+
+@check_inited
+@check_user
+def turn_on(sync_schains, env_file, node_type: NodeType) -> None:
+    node_mode = upsert_node_mode()
+    env = compose_node_env(
+        env_file,
+        inited_node=True,
+        sync_schains=sync_schains,
+        node_type=node_type,
+        node_mode=node_mode,
+    )
+    turn_on_op(env=env, node_type=node_type, node_mode=node_mode)
+    logger.info('Waiting for containers initialization')
+    time.sleep(TM_INIT_TIMEOUT)
+    if not is_base_containers_alive(node_type=node_type, node_mode=node_mode):
+        print_node_cmd_error()
+        return
+    logger.info('Node turned on')

--- a/node_cli/fair/staking.py
+++ b/node_cli/fair/staking.py
@@ -18,6 +18,8 @@
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from typing import Any
+import json
+from datetime import datetime, timezone
 
 from node_cli.utils.decorators import check_inited
 from node_cli.utils.exit_codes import CLIExitCodes
@@ -50,12 +52,27 @@ def remove_allowed_receiver(receiver: str) -> None:
 
 
 @check_inited
-def send_fees(to: str, amount: float | None) -> None:
+def request_fees(amount: float | None) -> None:
+    json_data: dict[str, Any] = {}
+    if amount is not None:
+        json_data['amount'] = amount
+    status, payload = post_request(blueprint=BLUEPRINT_NAME, method='request-fees', json=json_data)
+    _handle_response(
+        status,
+        payload,
+        success='All fees requested' if amount is None else f'Fees requested: {amount}',
+    )
+
+
+@check_inited
+def request_send_fees(to: str, amount: float | None) -> None:
     json_data: dict[str, Any] = {'to': to}
     if amount is not None:
         json_data['amount'] = amount
-    status, payload = post_request(blueprint=BLUEPRINT_NAME, method='send-fees', json=json_data)
-    _handle_response(status, payload, success=f'Fees sent to {to}')
+    status, payload = post_request(
+        blueprint=BLUEPRINT_NAME, method='request-send-fees', json=json_data
+    )
+    _handle_response(status, payload, success=f'Fees request to send to {to} created')
 
 
 @check_inited
@@ -67,16 +84,11 @@ def set_fee_rate(fee_rate: int) -> None:
 
 
 @check_inited
-def claim_fees(amount: float | None) -> None:
-    json_data: dict[str, Any] = {}
-    if amount is not None:
-        json_data['amount'] = amount
-    status, payload = post_request(blueprint=BLUEPRINT_NAME, method='claim-fees', json=json_data)
-    _handle_response(
-        status,
-        payload,
-        success='All fees claimed' if amount is None else f'Fees claimed: {amount}',
+def claim_request(request_id: int) -> None:
+    status, payload = post_request(
+        blueprint=BLUEPRINT_NAME, method='claim-request', json={'requestId': request_id}
     )
+    _handle_response(status, payload, success=f'Request claimed: {request_id}')
 
 
 @check_inited
@@ -86,5 +98,41 @@ def get_earned_fee_amount() -> None:
         amount_wei = payload.get('amount_wei')
         amount_ether = payload.get('amount_ether')
         print(f'Earned fee amount: {amount_wei} wei ({amount_ether} FAIR)')
+        return
+    error_exit(payload, exit_code=CLIExitCodes.BAD_API_RESPONSE)
+
+
+@check_inited
+def get_exit_requests(raw: bool = False) -> None:
+    status, payload = post_request(blueprint=BLUEPRINT_NAME, method='get-exit-requests')
+    if status == 'ok' and isinstance(payload, dict):
+        exit_requests = payload.get('exit_requests')
+        if not isinstance(exit_requests, list):
+            error_exit(payload, exit_code=CLIExitCodes.BAD_API_RESPONSE)
+            return
+        if raw:
+            print(json.dumps(exit_requests, indent=2))
+            return
+        for req in exit_requests:
+            try:
+                request_id = req.get('request_id')
+                user = req.get('user')
+                node_id = req.get('node_id')
+                amount = req.get('amount')
+                unlock_date = req.get('unlock_date')
+                amount_fair = None
+                if isinstance(amount, int):
+                    amount_fair = amount / 10**18
+                unlock_iso = None
+                if isinstance(unlock_date, int):
+                    unlock_iso = datetime.fromtimestamp(unlock_date, tz=timezone.utc).isoformat()
+                base = (
+                    f'request_id: {request_id} | user: {user} | node_id: {node_id} | '
+                    f'amount_wei: {amount} | amount_fair: {amount_fair} | '
+                    f'unlock_date: {unlock_date}'
+                )
+                print(base + (f' ({unlock_iso})' if unlock_iso else ''))
+            except Exception:  # noqa: BLE001
+                print(req)
         return
     error_exit(payload, exit_code=CLIExitCodes.BAD_API_RESPONSE)

--- a/node_cli/operations/base.py
+++ b/node_cli/operations/base.py
@@ -359,14 +359,23 @@ def turn_off(env: dict, node_type: NodeType, node_mode: NodeMode) -> None:
 
 def turn_on(env: dict, node_type: NodeType, node_mode: NodeMode) -> None:
     logger.info('Turning on the node...')
-    meta_manager = CliMetaManager()
-    meta_manager.update_meta(
-        VERSION,
-        env['NODE_VERSION'],
-        env['DOCKER_LVMPY_VERSION'],
-        distro.id(),
-        distro.version(),
-    )
+    if node_type == NodeType.FAIR:
+        meta_manager = FairCliMetaManager()
+        meta_manager.update_meta(
+            VERSION,
+            env['NODE_VERSION'],
+            distro.id(),
+            distro.version(),
+        )
+    else:
+        meta_manager = CliMetaManager()
+        meta_manager.update_meta(
+            VERSION,
+            env['NODE_VERSION'],
+            env['DOCKER_LVMPY_VERSION'],
+            distro.id(),
+            distro.version()
+        )
     if env.get('SKIP_DOCKER_CONFIG') != 'True':
         configure_docker()
 

--- a/tests/routes_test.py
+++ b/tests/routes_test.py
@@ -42,9 +42,11 @@ ALL_V1_ROUTES = [
     '/api/v1/fair-staking/add-receiver',
     '/api/v1/fair-staking/remove-receiver',
     '/api/v1/fair-staking/set-fee-rate',
-    '/api/v1/fair-staking/claim-fees',
-    '/api/v1/fair-staking/send-fees',
+    '/api/v1/fair-staking/request-fees',
+    '/api/v1/fair-staking/request-send-fees',
+    '/api/v1/fair-staking/claim-request',
     '/api/v1/fair-staking/get-earned-fee-amount',
+    '/api/v1/fair-staking/get-exit-requests',
 ]
 
 


### PR DESCRIPTION
This pull request introduces new node lifecycle commands and refactors the staking fee request workflow for both active and passive Fair nodes. The CLI now supports explicit turn-on and turn-off commands, and the staking fee claiming process has been updated to a request-based workflow, including new commands and improved output for exit requests. The documentation (`README.md`), CLI code, and related route definitions have all been updated to reflect these changes.

**Node lifecycle management:**

* Added `turn-on` and `turn-off` commands for both active (`fair node`) and passive (`fair passive-node`) Fair nodes, allowing explicit control over node container state via the CLI. [[1]](diffhunk://#diff-2f82f30c374ab8a51e09163549a12b05544deb7793f40e09c028aa2457d91364R200-R226) [[2]](diffhunk://#diff-4c709cc566179479c162f75ac17db239204e4366e95e49237797e1c3096bf25dR125-R151) [[3]](diffhunk://#diff-a6b253ee2676f6f2dd5f85aebe05e0504677f9052dee3bde3fca3890d78fa531R139-R167)
* Updated the `README.md` to document these new commands and their options. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R831-R859) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1237-R1265)

**Staking fee workflow refactor:**

* Replaced direct fee claiming and sending commands (`claim-fees`, `send-fees`) with a request-based workflow (`request-fees`, `request-send-fees`, `claim-request`). This includes new CLI commands and corresponding backend logic. [[1]](diffhunk://#diff-02de47bd3a465d6a447238abc4ee25d7e7ca504652573d0245ab90e69762eecaL82-R141) [[2]](diffhunk://#diff-ccb3ed613dd4c625ea28296a22663912195d784659d62dd5c5222d153fb81310L53-R75) [[3]](diffhunk://#diff-ccb3ed613dd4c625ea28296a22663912195d784659d62dd5c5222d153fb81310L70-R91) [[4]](diffhunk://#diff-12132dde0bdef91d2276291fd892108242ea0254c453d6829b544adc06a76b40L50-R54) [[5]](diffhunk://#diff-d81e73c3c932063b87df06ac64485eb6e3a636abd58caf1b9ac62702ffcbd2faL45-R49) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1101-R1193)
* Added a command to list exit (fee withdrawal) requests with both human-readable and JSON output formats. [[1]](diffhunk://#diff-02de47bd3a465d6a447238abc4ee25d7e7ca504652573d0245ab90e69762eecaL82-R141) [[2]](diffhunk://#diff-ccb3ed613dd4c625ea28296a22663912195d784659d62dd5c5222d153fb81310R103-R138) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1101-R1193)

**Supporting changes:**

* Updated route definitions and tests to match the new request-based staking workflow. [[1]](diffhunk://#diff-12132dde0bdef91d2276291fd892108242ea0254c453d6829b544adc06a76b40L50-R54) [[2]](diffhunk://#diff-d81e73c3c932063b87df06ac64485eb6e3a636abd58caf1b9ac62702ffcbd2faL45-R49)
* Minor improvements and code organization in CLI and common modules to support new features. [[1]](diffhunk://#diff-a6b253ee2676f6f2dd5f85aebe05e0504677f9052dee3bde3fca3890d78fa531L20-L42) [[2]](diffhunk://#diff-ccb3ed613dd4c625ea28296a22663912195d784659d62dd5c5222d153fb81310R21-R22) [[3]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653R362-R377)