### PR TITLE
Fix snapshot option for passive nodes, add logs

### DIFF
--- a/node_cli/fair/record/redis_record.py
+++ b/node_cli/fair/record/redis_record.py
@@ -18,6 +18,7 @@
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import abc
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -25,6 +26,8 @@ from typing import Any
 import redis
 
 from node_cli.configs import REDIS_URI
+
+logger = logging.getLogger(__name__)
 
 cpool: redis.ConnectionPool = redis.ConnectionPool.from_url(REDIS_URI)
 rs: redis.Redis = redis.Redis(connection_pool=cpool)
@@ -83,6 +86,7 @@ class FlatRedisRecord:
     def _set_field(self, field_name: str, value) -> None:
         key = self._get_field_key(field_name)
         serialized_value = self._serialize_field(value, self._record_fields()[field_name].type)
+        logger.info('Setting field %s to value %s', field_name, serialized_value)
         rs.set(key, serialized_value)
 
     def _deserialize_field(self, value, field_type: type):

--- a/node_cli/operations/fair.py
+++ b/node_cli/operations/fair.py
@@ -112,8 +112,10 @@ def init(
 
     upsert_node_mode(node_mode=node_mode)
     if node_mode == NodeMode.PASSIVE:
+        logger.info('Setting passive node options')
         set_passive_node_options(archive=archive, indexer=indexer)
         if snapshot:
+            logger.info('Waiting %s seconds for redis to start', REDIS_START_TIMEOUT)
             time.sleep(REDIS_START_TIMEOUT)
             trigger_skaled_snapshot_mode(env=env, snapshot_from=snapshot)
 
@@ -293,6 +295,7 @@ def trigger_skaled_snapshot_mode(env: dict, snapshot_from: str = 'any') -> None:
     record = get_fair_chain_record(env)
     if not snapshot_from:
         snapshot_from = 'any'
+    logger.info('Triggering skaled snapshot mode, snapshot_from: %s', snapshot_from)
     record.set_snapshot_from(snapshot_from)
 
 

--- a/node_cli/utils/helper.py
+++ b/node_cli/utils/helper.py
@@ -382,13 +382,13 @@ class UrlType(click.ParamType):
         return value
 
 
-class UrlOrAnyType(click.ParamType):
+class UrlOrAnyType(UrlType):
     name = 'url'
 
     def convert(self, value, param, ctx):
         if value == 'any':
             return value
-        super().convert(value, param, ctx)
+        return super().convert(value, param, ctx)
 
 
 class IpType(click.ParamType):

--- a/tests/cli/fair_passive_node_test.py
+++ b/tests/cli/fair_passive_node_test.py
@@ -1,0 +1,86 @@
+import logging
+import pathlib
+
+import mock
+
+from node_cli.cli.passive_fair_node import init_passive_node, update_node
+from node_cli.configs import NODE_DATA_PATH, SKALE_DIR
+from node_cli.utils.helper import init_default_logger
+from tests.helper import run_command, subprocess_run_mock
+from tests.resources_test import BIG_DISK_SIZE
+
+logger = logging.getLogger(__name__)
+init_default_logger()
+
+
+def test_init_fair_passive(mocked_g_config, tmp_path):
+    env_file = tmp_path / 'test-env'
+    env_file.write_text('')
+    pathlib.Path(SKALE_DIR).mkdir(parents=True, exist_ok=True)
+    with (
+        mock.patch('subprocess.run', new=subprocess_run_mock),
+        mock.patch('node_cli.fair.common.init_fair_op', return_value=True),
+        mock.patch('node_cli.fair.common.compose_node_env', return_value={}),
+        mock.patch('node_cli.fair.common.save_env_params'),
+        mock.patch('node_cli.fair.passive.setup_fair_passive'),
+        mock.patch('node_cli.fair.common.time.sleep'),
+        mock.patch('node_cli.core.node.is_base_containers_alive', return_value=True),
+        mock.patch('node_cli.core.resources.get_disk_size', return_value=BIG_DISK_SIZE),
+        mock.patch('node_cli.operations.base.configure_nftables'),
+        mock.patch('node_cli.utils.decorators.is_node_inited', return_value=False),
+    ):
+        result = run_command(
+            init_passive_node,
+            [
+                env_file.as_posix(),
+                '--id',
+                '1',
+            ],
+        )
+        assert result.exit_code == 0
+
+
+def test_init_fair_passive_snapshot_any(mocked_g_config, tmp_path):
+    env_file = tmp_path / 'test-env'
+    env_file.write_text('')
+    pathlib.Path(SKALE_DIR).mkdir(parents=True, exist_ok=True)
+    with (
+        mock.patch('subprocess.run', new=subprocess_run_mock),
+        mock.patch('node_cli.fair.common.init_fair_op', return_value=True),
+        mock.patch('node_cli.fair.common.compose_node_env', return_value={}),
+        mock.patch('node_cli.fair.common.save_env_params'),
+        mock.patch('node_cli.fair.passive.setup_fair_passive'),
+        mock.patch('node_cli.fair.common.time.sleep'),
+        mock.patch('node_cli.core.node.is_base_containers_alive', return_value=True),
+        mock.patch('node_cli.core.resources.get_disk_size', return_value=BIG_DISK_SIZE),
+        mock.patch('node_cli.operations.base.configure_nftables'),
+        mock.patch('node_cli.utils.decorators.is_node_inited', return_value=False),
+    ):
+        result = run_command(
+            init_passive_node,
+            [
+                env_file.as_posix(),
+                '--id',
+                '2',
+                '--snapshot',
+                'any',
+            ],
+        )
+        assert result.exit_code == 0
+
+
+def test_update_fair_passive(mocked_g_config, tmp_path):
+    env_file = tmp_path / 'test-env'
+    env_file.write_text('')
+    pathlib.Path(NODE_DATA_PATH).mkdir(parents=True, exist_ok=True)
+    with (
+        mock.patch('subprocess.run', new=subprocess_run_mock),
+        mock.patch('node_cli.fair.common.update_fair_op', return_value=True),
+        mock.patch('node_cli.fair.common.compose_node_env', return_value={}),
+        mock.patch('node_cli.core.node.is_base_containers_alive', return_value=True),
+        mock.patch('node_cli.core.resources.get_disk_size', return_value=BIG_DISK_SIZE),
+        mock.patch('node_cli.operations.base.configure_nftables'),
+        mock.patch('node_cli.utils.decorators.is_node_inited', return_value=True),
+    ):
+        result = run_command(update_node, [env_file.as_posix(), '--yes'])
+        assert result.exit_code == 0

--- a/tests/cli/passive_node_test.py
+++ b/tests/cli/passive_node_test.py
@@ -57,6 +57,37 @@ def test_init_passive(mocked_g_config, clean_node_options, passive_user_conf):
         assert result.exit_code == 0
 
 
+def test_init_passive_snapshot_any(mocked_g_config, clean_node_options, passive_user_conf):
+    pathlib.Path(NODE_DATA_PATH).mkdir(parents=True, exist_ok=True)
+    with (
+        mock.patch('node_cli.core.node.is_base_containers_alive', return_value=True),
+        mock.patch('node_cli.operations.base.cleanup_volume_artifacts'),
+        mock.patch('node_cli.operations.base.download_skale_node'),
+        mock.patch('node_cli.operations.base.sync_skale_node'),
+        mock.patch('node_cli.operations.base.configure_docker'),
+        mock.patch('node_cli.operations.base.prepare_host'),
+        mock.patch('node_cli.operations.base.ensure_filestorage_mapping'),
+        mock.patch('node_cli.operations.base.link_env_file'),
+        mock.patch('node_cli.operations.base.generate_nginx_config'),
+        mock.patch('node_cli.operations.base.prepare_block_device'),
+        mock.patch('node_cli.operations.base.CliMetaManager.update_meta'),
+        mock.patch('node_cli.operations.base.update_resource_allocation'),
+        mock.patch('node_cli.operations.base.update_images'),
+        mock.patch('node_cli.core.resources.get_disk_size', return_value=BIG_DISK_SIZE),
+        mock.patch('node_cli.operations.base.configure_nftables'),
+        mock.patch('node_cli.utils.decorators.is_node_inited', return_value=False),
+        mock.patch('node_cli.configs.user.validate_alias_or_address'),
+        mock.patch('node_cli.cli.node.TYPE', NodeType.SKALE),
+        mock.patch('node_cli.operations.base.compose_up') as compose_up_mock,
+    ):
+        result = run_command(_init_passive, [passive_user_conf.as_posix(), '--snapshot', 'any'])
+        assert result.exit_code == 0
+        assert compose_up_mock.called
+        args, kwargs = compose_up_mock.call_args
+        assert 'snapshot' in kwargs
+        assert kwargs['snapshot'] == 'any'
+
+
 def test_init_passive_archive(mocked_g_config, clean_node_options, passive_user_conf):
     pathlib.Path(NODE_DATA_PATH).mkdir(parents=True, exist_ok=True)
     with (

--- a/tests/cli/passive_node_test.py
+++ b/tests/cli/passive_node_test.py
@@ -57,37 +57,6 @@ def test_init_passive(mocked_g_config, clean_node_options, passive_user_conf):
         assert result.exit_code == 0
 
 
-def test_init_passive_snapshot_any(mocked_g_config, clean_node_options, passive_user_conf):
-    pathlib.Path(NODE_DATA_PATH).mkdir(parents=True, exist_ok=True)
-    with (
-        mock.patch('node_cli.core.node.is_base_containers_alive', return_value=True),
-        mock.patch('node_cli.operations.base.cleanup_volume_artifacts'),
-        mock.patch('node_cli.operations.base.download_skale_node'),
-        mock.patch('node_cli.operations.base.sync_skale_node'),
-        mock.patch('node_cli.operations.base.configure_docker'),
-        mock.patch('node_cli.operations.base.prepare_host'),
-        mock.patch('node_cli.operations.base.ensure_filestorage_mapping'),
-        mock.patch('node_cli.operations.base.link_env_file'),
-        mock.patch('node_cli.operations.base.generate_nginx_config'),
-        mock.patch('node_cli.operations.base.prepare_block_device'),
-        mock.patch('node_cli.operations.base.CliMetaManager.update_meta'),
-        mock.patch('node_cli.operations.base.update_resource_allocation'),
-        mock.patch('node_cli.operations.base.update_images'),
-        mock.patch('node_cli.core.resources.get_disk_size', return_value=BIG_DISK_SIZE),
-        mock.patch('node_cli.operations.base.configure_nftables'),
-        mock.patch('node_cli.utils.decorators.is_node_inited', return_value=False),
-        mock.patch('node_cli.configs.user.validate_alias_or_address'),
-        mock.patch('node_cli.cli.node.TYPE', NodeType.SKALE),
-        mock.patch('node_cli.operations.base.compose_up') as compose_up_mock,
-    ):
-        result = run_command(_init_passive, [passive_user_conf.as_posix(), '--snapshot', 'any'])
-        assert result.exit_code == 0
-        assert compose_up_mock.called
-        args, kwargs = compose_up_mock.call_args
-        assert 'snapshot' in kwargs
-        assert kwargs['snapshot'] == 'any'
-
-
 def test_init_passive_archive(mocked_g_config, clean_node_options, passive_user_conf):
     pathlib.Path(NODE_DATA_PATH).mkdir(parents=True, exist_ok=True)
     with (


### PR DESCRIPTION
This pull request introduces improvements to logging, type handling, and test coverage in the node CLI codebase. The main changes include adding informative logging statements to key operations, fixing a type inheritance issue, and expanding tests for passive node initialization with snapshots.

**Logging enhancements:**

* Added a `logger` instance to `redis_record.py` and inserted info-level logs when setting Redis fields in `RedisRecord._set_field`, providing better visibility into field updates. [[1]](diffhunk://#diff-5312cadd2f88c72f8f8bed672c669e44e2f948328e2b39b94cb78913966c998dR21) [[2]](diffhunk://#diff-5312cadd2f88c72f8f8bed672c669e44e2f948328e2b39b94cb78913966c998dR30-R31) [[3]](diffhunk://#diff-5312cadd2f88c72f8f8bed672c669e44e2f948328e2b39b94cb78913966c998dR89)
* Added info-level logging in `fair.py` for setting passive node options, waiting for Redis startup, and triggering skaled snapshot mode, improving traceability of node initialization steps. [[1]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cR115-R118) [[2]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cR298)

**Type handling fix:**

* Updated `UrlOrAnyType` in `helper.py` to inherit from `UrlType` instead of `click.ParamType`, and corrected its `convert` method to properly handle the 'any' value and delegate other values to the parent class, ensuring correct parameter parsing.

**Test coverage improvements:**

* Added a new test `test_init_passive_snapshot_any` in `passive_node_test.py` to verify passive node initialization with the `--snapshot any` option, including checks for correct argument passing to `compose_up`.