### PR TITLE
Fix init and update commands for SKALE nodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,18 @@ FROM python:3.11-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt install -y \
-                       git \
-                       build-essential \
-                       software-properties-common \
-                       zlib1g-dev \
-                       libssl-dev \
-                       libffi-dev \
-                       swig \
-                       iptables \
-                       nftables \ 
-                       python3-nftables \ 
-                       libxslt-dev \
-                       kmod
+    git \
+    build-essential \
+    software-properties-common \
+    zlib1g-dev \
+    libssl-dev \
+    libffi-dev \
+    swig \
+    iptables \
+    nftables \ 
+    python3-nftables \ 
+    libxslt-dev \
+    kmod
 
 
 RUN mkdir /app

--- a/node_cli/core/node.py
+++ b/node_cli/core/node.py
@@ -157,7 +157,7 @@ def init(env_filepath: str, node_type: NodeType) -> None:
     node_mode = NodeMode.ACTIVE
     env = compose_node_env(env_filepath=env_filepath, node_type=node_type, node_mode=node_mode)
 
-    init_op(env_filepath=env_filepath, env=env, node_type=node_type, node_mode=node_mode)
+    init_op(env_filepath=env_filepath, env=env, node_mode=node_mode)
     logger.info('Waiting for containers initialization')
     time.sleep(TM_INIT_TIMEOUT)
     if not is_base_containers_alive(node_type=node_type, node_mode=node_mode):
@@ -314,7 +314,7 @@ def update(
         node_type=node_type,
         node_mode=node_mode,
     )
-    update_ok = update_op(env_filepath, env, node_type=node_type, node_mode=node_mode)
+    update_ok = update_op(env_filepath, env, node_mode=node_mode)
     if update_ok:
         logger.info('Waiting for containers initialization')
         time.sleep(TM_INIT_TIMEOUT)

--- a/node_cli/operations/base.py
+++ b/node_cli/operations/base.py
@@ -114,8 +114,8 @@ def checked_host(func):
 
 
 @checked_host
-def update(env_filepath: str, env: Dict, node_type: NodeType, node_mode: NodeMode) -> bool:
-    compose_rm(node_type=node_type, node_mode=node_mode, env=env)
+def update(env_filepath: str, env: Dict, node_mode: NodeMode) -> bool:
+    compose_rm(node_type=NodeType.SKALE, node_mode=node_mode, env=env)
     remove_dynamic_containers()
 
     sync_skale_node()
@@ -151,8 +151,8 @@ def update(env_filepath: str, env: Dict, node_type: NodeType, node_mode: NodeMod
         distro.id(),
         distro.version(),
     )
-    update_images(env=env, node_type=node_type, node_mode=node_mode)
-    compose_up(env=env, node_type=node_type, node_mode=node_mode)
+    update_images(env=env, node_type=NodeType.SKALE, node_mode=node_mode)
+    compose_up(env=env, node_type=NodeType.SKALE, node_mode=node_mode)
     return True
 
 
@@ -199,7 +199,7 @@ def update_fair_boot(env_filepath: str, env: Dict, node_mode: NodeMode = NodeMod
 
 
 @checked_host
-def init(env_filepath: str, env: dict, node_type: NodeType, node_mode: NodeMode) -> None:
+def init(env_filepath: str, env: dict, node_mode: NodeMode) -> None:
     sync_skale_node()
     ensure_btrfs_kernel_module_autoloaded()
     if env.get('SKIP_DOCKER_CONFIG') != 'True':
@@ -229,9 +229,8 @@ def init(env_filepath: str, env: dict, node_type: NodeType, node_mode: NodeMode)
         distro.version(),
     )
     update_resource_allocation(env_type=env['ENV_TYPE'])
-    update_images(env=env, node_type=node_type, node_mode=node_mode)
-
-    compose_up(env=env, node_type=node_type, node_mode=node_mode)
+    update_images(env=env, node_type=NodeType.SKALE, node_mode=node_mode)
+    compose_up(env=env, node_type=NodeType.SKALE, node_mode=node_mode)
 
 
 @checked_host
@@ -370,11 +369,7 @@ def turn_on(env: dict, node_type: NodeType, node_mode: NodeMode) -> None:
     else:
         meta_manager = CliMetaManager()
         meta_manager.update_meta(
-            VERSION,
-            env['NODE_VERSION'],
-            env['DOCKER_LVMPY_VERSION'],
-            distro.id(),
-            distro.version()
+            VERSION, env['NODE_VERSION'], env['DOCKER_LVMPY_VERSION'], distro.id(), distro.version()
         )
     if env.get('SKIP_DOCKER_CONFIG') != 'True':
         configure_docker()


### PR DESCRIPTION
This pull request refactors the initialization and update operations for nodes by removing the `node_type` parameter from several functions and standardizing the use of `NodeType.SKALE` within these operations. The changes simplify the function signatures and ensure consistent handling of node types during initialization and update processes.

**Refactoring of function parameters and node type handling:**

* Removed the `node_type` parameter from the `init` and `update` functions in both `node_cli/core/node.py` and `node_cli/operations/base.py`, and updated all calls accordingly. (`[[1]](diffhunk://#diff-cd8b3a0d0a5921ad426729c3dbcd0ae7a148dd6772be2cc807da4316dd166050L160-R160)`, `[[2]](diffhunk://#diff-cd8b3a0d0a5921ad426729c3dbcd0ae7a148dd6772be2cc807da4316dd166050L317-R317)`, `[[3]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L202-R202)`)
* Standardized the use of `NodeType.SKALE` for all Docker compose and image update operations within the `init` and `update` functions, replacing dynamic `node_type` arguments. (`[[1]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L117-R118)`, `[[2]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L154-R155)`, `[[3]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L232-R233)`)

**Code style and minor formatting:**

* Minor formatting change to the `meta_manager.update_meta` call in the `turn_on` function for improved readability. (`[node_cli/operations/base.pyL373-R372](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L373-R372)`)