### PR TITLE
Add cleanup commands for skale nodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,18 @@ FROM python:3.11-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt install -y \
-                       git \
-                       build-essential \
-                       software-properties-common \
-                       zlib1g-dev \
-                       libssl-dev \
-                       libffi-dev \
-                       swig \
-                       iptables \
-                       nftables \ 
-                       python3-nftables \ 
-                       libxslt-dev \
-                       kmod
+    git \
+    build-essential \
+    software-properties-common \
+    zlib1g-dev \
+    libssl-dev \
+    libffi-dev \
+    swig \
+    iptables \
+    nftables \ 
+    python3-nftables \ 
+    libxslt-dev \
+    kmod
 
 
 RUN mkdir /app

--- a/node_cli/cli/fair_node.py
+++ b/node_cli/cli/fair_node.py
@@ -152,17 +152,18 @@ def repair(snapshot: str = 'any') -> None:
     repair_chain(snapshot_from=snapshot)
 
 
-@node.command('cleanup', help='Cleanup Fair node.')
+@node.command('cleanup', help='Remove all FAIR node data and containers.')
 @click.option(
     '--yes',
     is_flag=True,
     callback=abort_if_false,
     expose_value=False,
-    prompt='Are you sure you want to cleanup Fair node?',
+    prompt='Are you sure you want to remove all FAIR node data and containers?',
 )
+@click.option('--prune', is_flag=True, help='Prune docker system.')
 @streamed_cmd
-def cleanup_node():
-    cleanup_fair(node_mode=NodeMode.ACTIVE)
+def cleanup_node(prune):
+    cleanup_fair(node_mode=NodeMode.ACTIVE, prune=prune)
 
 
 @node.command('change-ip', help=TEXTS['fair']['node']['change-ip']['help'])

--- a/node_cli/cli/node.py
+++ b/node_cli/cli/node.py
@@ -260,7 +260,7 @@ def version(raw: bool) -> None:
         print_meta_info(meta_info)
 
 
-@node.command('cleanup', help='Remove all SKALE node data and containers..')
+@node.command('cleanup', help='Remove all SKALE node data and containers.')
 @click.option(
     '--yes',
     is_flag=True,
@@ -270,5 +270,5 @@ def version(raw: bool) -> None:
 )
 @click.option('--prune', is_flag=True, help='Prune docker system.')
 @streamed_cmd
-def _cleanup_node(prune):
+def cleanup_node(prune):
     cleanup_skale(node_mode=NodeMode.ACTIVE, prune=prune)

--- a/node_cli/cli/node.py
+++ b/node_cli/cli/node.py
@@ -21,6 +21,7 @@ import click
 
 from node_cli.cli.info import TYPE
 from node_cli.core.node import (
+    cleanup as cleanup_skale,
     configure_firewall_rules,
     get_node_signature,
     init,
@@ -257,3 +258,16 @@ def version(raw: bool) -> None:
         print(meta_info)
     else:
         print_meta_info(meta_info)
+
+
+@node.command('cleanup', help='Remove all SKALE node data and containers..')
+@click.option(
+    '--yes',
+    is_flag=True,
+    callback=abort_if_false,
+    expose_value=False,
+    prompt='Are you sure you want to remove all SKALE node data and containers?',
+)
+@streamed_cmd
+def cleanup_node():
+    cleanup_skale(node_mode=NodeMode.ACTIVE)

--- a/node_cli/cli/node.py
+++ b/node_cli/cli/node.py
@@ -268,6 +268,7 @@ def version(raw: bool) -> None:
     expose_value=False,
     prompt='Are you sure you want to remove all SKALE node data and containers?',
 )
+@click.option('--prune', is_flag=True, help='Prune docker system.')
 @streamed_cmd
-def cleanup_node():
-    cleanup_skale(node_mode=NodeMode.ACTIVE)
+def cleanup_node(prune):
+    cleanup_skale(node_mode=NodeMode.ACTIVE, prune=prune)

--- a/node_cli/cli/node.py
+++ b/node_cli/cli/node.py
@@ -270,5 +270,5 @@ def version(raw: bool) -> None:
 )
 @click.option('--prune', is_flag=True, help='Prune docker system.')
 @streamed_cmd
-def cleanup_node(prune):
+def _cleanup_node(prune):
     cleanup_skale(node_mode=NodeMode.ACTIVE, prune=prune)

--- a/node_cli/cli/passive_fair_node.py
+++ b/node_cli/cli/passive_fair_node.py
@@ -105,17 +105,18 @@ def update_node(env_filepath: str, pull_config_for_schain, force_skaled_start: b
     )
 
 
-@passive_node.command('cleanup', help='Cleanup Fair node.')
+@passive_node.command('cleanup', help='Remove all FAIR node data and containers.')
 @click.option(
     '--yes',
     is_flag=True,
     callback=abort_if_false,
     expose_value=False,
-    prompt='Are you sure you want to cleanup Fair node?',
+    prompt='Are you sure you want to remove all FAIR node data and containers?',
 )
+@click.option('--prune', is_flag=True, help='Prune docker system.')
 @streamed_cmd
-def cleanup_node():
-    cleanup_fair(node_mode=NodeMode.PASSIVE)
+def cleanup_node(prune):
+    cleanup_fair(node_mode=NodeMode.PASSIVE, prune=prune)
 
 
 @passive_node.command('setup', help=TEXTS['fair']['node']['setup']['help'])

--- a/node_cli/cli/passive_node.py
+++ b/node_cli/cli/passive_node.py
@@ -73,7 +73,7 @@ def _update_passive(env_file, unsafe_ok):
     update_passive(env_file)
 
 
-@passive_node.command('cleanup', help='Remove all passive SKALE node data and containers.')
+@passive_node.command('cleanup', help='Remove all SKALE node data and containers.')
 @click.option(
     '--yes',
     is_flag=True,
@@ -83,5 +83,5 @@ def _update_passive(env_file, unsafe_ok):
 )
 @click.option('--prune', is_flag=True, help='Prune docker system.')
 @streamed_cmd
-def _cleanup_node(prune):
+def cleanup_node(prune):
     cleanup_skale(node_mode=NodeMode.PASSIVE, prune=prune)

--- a/node_cli/cli/passive_node.py
+++ b/node_cli/cli/passive_node.py
@@ -81,6 +81,7 @@ def _update_passive(env_file, unsafe_ok):
     expose_value=False,
     prompt='Are you sure you want to remove all SKALE node data and containers?',
 )
+@click.option('--prune', is_flag=True, help='Prune docker system.')
 @streamed_cmd
-def cleanup_node():
-    cleanup_skale(node_mode=NodeMode.PASSIVE)
+def cleanup_node(prune):
+    cleanup_skale(node_mode=NodeMode.PASSIVE, prune=prune)

--- a/node_cli/cli/passive_node.py
+++ b/node_cli/cli/passive_node.py
@@ -21,8 +21,9 @@ from typing import Optional
 
 import click
 
-from node_cli.core.node import init_passive, update_passive, cleanup_passive
+from node_cli.core.node import init_passive, update_passive, cleanup as cleanup_skale
 from node_cli.utils.helper import abort_if_false, error_exit, streamed_cmd, URL_TYPE
+from node_cli.utils.node_type import NodeMode
 from node_cli.utils.texts import safe_load_texts
 
 
@@ -72,14 +73,14 @@ def _update_passive(env_file, unsafe_ok):
     update_passive(env_file)
 
 
-@passive_node.command('cleanup', help='Remove passive node data and containers')
+@passive_node.command('cleanup', help='Remove all passive SKALE node data and containers.')
 @click.option(
     '--yes',
     is_flag=True,
     callback=abort_if_false,
     expose_value=False,
-    prompt='Are you sure you want to remove all node containers and data?',
+    prompt='Are you sure you want to remove all SKALE node data and containers?',
 )
 @streamed_cmd
-def _cleanup_passive() -> None:
-    cleanup_passive()
+def cleanup_node():
+    cleanup_skale(node_mode=NodeMode.PASSIVE)

--- a/node_cli/cli/passive_node.py
+++ b/node_cli/cli/passive_node.py
@@ -83,5 +83,5 @@ def _update_passive(env_file, unsafe_ok):
 )
 @click.option('--prune', is_flag=True, help='Prune docker system.')
 @streamed_cmd
-def cleanup_node(prune):
+def _cleanup_node(prune):
     cleanup_skale(node_mode=NodeMode.PASSIVE, prune=prune)

--- a/node_cli/configs/user.py
+++ b/node_cli/configs/user.py
@@ -143,6 +143,7 @@ def get_validated_user_config(
     node_mode: NodeMode,
     env_filepath: str = SKALE_DIR_ENV_FILEPATH,
     is_fair_boot: bool = False,
+    skip_usr_conf_validation: bool = False,
 ) -> BaseUserConfig:
     params = parse_env_file(env_filepath)
     user_config_class = get_user_config_class(
@@ -160,7 +161,8 @@ def get_validated_user_config(
 
     params = to_lower_keys(params)
     user_config = user_config_class(**params)
-    validate_user_config(user_config)
+    if not skip_usr_conf_validation:
+        validate_user_config(user_config)
 
     return user_config
 

--- a/node_cli/configs/user.py
+++ b/node_cli/configs/user.py
@@ -143,7 +143,7 @@ def get_validated_user_config(
     node_mode: NodeMode,
     env_filepath: str = SKALE_DIR_ENV_FILEPATH,
     is_fair_boot: bool = False,
-    skip_usr_conf_validation: bool = False,
+    skip_user_conf_validation: bool = False,
 ) -> BaseUserConfig:
     params = parse_env_file(env_filepath)
     user_config_class = get_user_config_class(
@@ -161,7 +161,7 @@ def get_validated_user_config(
 
     params = to_lower_keys(params)
     user_config = user_config_class(**params)
-    if not skip_usr_conf_validation:
+    if not skip_user_conf_validation:
         validate_user_config(user_config)
 
     return user_config

--- a/node_cli/core/node.py
+++ b/node_cli/core/node.py
@@ -157,7 +157,7 @@ def init(env_filepath: str, node_type: NodeType) -> None:
     node_mode = NodeMode.ACTIVE
     env = compose_node_env(env_filepath=env_filepath, node_type=node_type, node_mode=node_mode)
 
-    init_op(env_filepath=env_filepath, env=env, node_type=node_type, node_mode=node_mode)
+    init_op(env_filepath=env_filepath, env=env, node_mode=node_mode)
     logger.info('Waiting for containers initialization')
     time.sleep(TM_INIT_TIMEOUT)
     if not is_base_containers_alive(node_type=node_type, node_mode=node_mode):
@@ -314,7 +314,7 @@ def update(
         node_type=node_type,
         node_mode=node_mode,
     )
-    update_ok = update_op(env_filepath, env, node_type=node_type, node_mode=node_mode)
+    update_ok = update_op(env_filepath, env, node_mode=node_mode)
     if update_ok:
         logger.info('Waiting for containers initialization')
         time.sleep(TM_INIT_TIMEOUT)

--- a/node_cli/core/node.py
+++ b/node_cli/core/node.py
@@ -229,7 +229,11 @@ def update_passive(env_filepath: str, unsafe_ok: bool = False) -> None:
 def cleanup(node_mode: NodeMode, prune: bool = False) -> None:
     node_mode = upsert_node_mode(node_mode=node_mode)
     env = compose_node_env(
-        SKALE_DIR_ENV_FILEPATH, save=False, node_type=NodeType.SKALE, node_mode=node_mode
+        SKALE_DIR_ENV_FILEPATH,
+        save=False,
+        node_type=NodeType.SKALE,
+        node_mode=node_mode,
+        skip_usr_conf_validation=True,
     )
     cleanup_skale_op(node_mode=node_mode, env=env, prune=prune)
     logger.info('SKALE node was cleaned up, all containers and data removed')
@@ -244,6 +248,7 @@ def compose_node_env(
     pull_config_for_schain: Optional[str] = None,
     save: bool = True,
     is_fair_boot: bool = False,
+    skip_usr_conf_validation: bool = False,
 ) -> dict[str, str]:
     if env_filepath is not None:
         user_config = get_validated_user_config(
@@ -251,6 +256,7 @@ def compose_node_env(
             node_mode=node_mode,
             env_filepath=env_filepath,
             is_fair_boot=is_fair_boot,
+            skip_usr_conf_validation=skip_usr_conf_validation,
         )
         if save:
             save_env_params(env_filepath)
@@ -259,6 +265,7 @@ def compose_node_env(
             node_type=node_type,
             env_filepath=INIT_ENV_FILEPATH,
             is_fair_boot=is_fair_boot,
+            skip_usr_conf_validation=skip_usr_conf_validation,
         )
 
     if node_mode == NodeMode.PASSIVE or node_type == NodeType.FAIR:

--- a/node_cli/core/node.py
+++ b/node_cli/core/node.py
@@ -227,12 +227,12 @@ def update_passive(env_filepath: str, unsafe_ok: bool = False) -> None:
 
 @check_inited
 @check_user
-def cleanup(node_mode: NodeMode) -> None:
+def cleanup(node_mode: NodeMode, prune: bool = False) -> None:
     node_mode = upsert_node_mode(node_mode=node_mode)
     env = compose_node_env(
         SKALE_DIR_ENV_FILEPATH, save=False, node_type=NodeType.SKALE, node_mode=node_mode
     )
-    cleanup_skale_op(node_mode=node_mode, env=env)
+    cleanup_skale_op(node_mode=node_mode, env=env, prune=prune)
     logger.info('SKALE node was cleaned up, all containers and data removed')
 
 

--- a/node_cli/core/node.py
+++ b/node_cli/core/node.py
@@ -233,7 +233,7 @@ def cleanup(node_mode: NodeMode, prune: bool = False) -> None:
         save=False,
         node_type=NodeType.SKALE,
         node_mode=node_mode,
-        skip_usr_conf_validation=True,
+        skip_user_conf_validation=True,
     )
     cleanup_skale_op(node_mode=node_mode, env=env, prune=prune)
     logger.info('SKALE node was cleaned up, all containers and data removed')
@@ -248,7 +248,7 @@ def compose_node_env(
     pull_config_for_schain: Optional[str] = None,
     save: bool = True,
     is_fair_boot: bool = False,
-    skip_usr_conf_validation: bool = False,
+    skip_user_conf_validation: bool = False,
 ) -> dict[str, str]:
     if env_filepath is not None:
         user_config = get_validated_user_config(
@@ -256,7 +256,7 @@ def compose_node_env(
             node_mode=node_mode,
             env_filepath=env_filepath,
             is_fair_boot=is_fair_boot,
-            skip_usr_conf_validation=skip_usr_conf_validation,
+            skip_user_conf_validation=skip_user_conf_validation,
         )
         if save:
             save_env_params(env_filepath)
@@ -265,7 +265,7 @@ def compose_node_env(
             node_type=node_type,
             env_filepath=INIT_ENV_FILEPATH,
             is_fair_boot=is_fair_boot,
-            skip_usr_conf_validation=skip_usr_conf_validation,
+            skip_user_conf_validation=skip_user_conf_validation,
         )
 
     if node_mode == NodeMode.PASSIVE or node_type == NodeType.FAIR:

--- a/node_cli/core/node.py
+++ b/node_cli/core/node.py
@@ -56,7 +56,7 @@ from node_cli.core.node_options import (
 )
 from node_cli.migrations.focal_to_jammy import migrate as migrate_2_6
 from node_cli.operations import (
-    cleanup_passive_op,
+    cleanup_skale_op,
     configure_nftables,
     init_op,
     init_passive_op,
@@ -227,13 +227,13 @@ def update_passive(env_filepath: str, unsafe_ok: bool = False) -> None:
 
 @check_inited
 @check_user
-def cleanup_passive() -> None:
+def cleanup(node_mode: NodeMode) -> None:
+    node_mode = upsert_node_mode(node_mode=node_mode)
     env = compose_node_env(
-        SKALE_DIR_ENV_FILEPATH, save=False, node_type=NodeType.SKALE, node_mode=NodeMode.PASSIVE
+        SKALE_DIR_ENV_FILEPATH, save=False, node_type=NodeType.SKALE, node_mode=node_mode
     )
-    schain_name = env['SCHAIN_NAME']
-    cleanup_passive_op(env, schain_name)
-    logger.info('Passive node was cleaned up, all containers and data removed')
+    cleanup_skale_op(node_mode=node_mode, env=env)
+    logger.info('SKALE node was cleaned up, all containers and data removed')
 
 
 def compose_node_env(

--- a/node_cli/core/node.py
+++ b/node_cli/core/node.py
@@ -225,7 +225,6 @@ def update_passive(env_filepath: str, unsafe_ok: bool = False) -> None:
         logger.info('Node update finished')
 
 
-@check_inited
 @check_user
 def cleanup(node_mode: NodeMode, prune: bool = False) -> None:
     node_mode = upsert_node_mode(node_mode=node_mode)

--- a/node_cli/core/schains.py
+++ b/node_cli/core/schains.py
@@ -299,6 +299,6 @@ def cleanup_no_lvm_datadir(
         if folder_name != 'shared-space':
             logger.info('Removing datadir content for %s', folder_path)
             cleanup_datadir_content(folder_path)
-        logger.info('Removing datadir content for %s', folder_path)
         if os.path.isdir(folder_path):
             shutil.rmtree(folder_path)
+    run_cmd(['umount', base_path])

--- a/node_cli/core/schains.py
+++ b/node_cli/core/schains.py
@@ -38,6 +38,7 @@ from node_cli.configs.user import get_validated_user_config
 from node_cli.utils.docker_utils import ensure_volume, is_volume_exists
 from node_cli.utils.exit_codes import CLIExitCodes
 from node_cli.utils.helper import (
+    cleanup_dir_content,
     error_exit,
     get_request,
     is_btrfs_subvolume,
@@ -302,3 +303,14 @@ def cleanup_no_lvm_datadir(
         if os.path.isdir(folder_path):
             shutil.rmtree(folder_path)
     run_cmd(['umount', base_path])
+
+
+def cleanup_lvm_datadir():
+    logger.info('Starting cleanup for active node...')
+    logger.info('Unmounting /mnt/schains-shared-space...')
+    run_cmd(['sudo', 'umount', '/mnt/schains-shared-space'], check_code=False)
+    logger.info('Cleaning up /mnt directory content...')
+    cleanup_dir_content('/mnt/')
+    logger.info('Removing LVM volume group "schains"...')
+    run_cmd(['sudo', 'lvremove', '-f', 'schains'], check_code=False)
+    logger.info('Active node cleanup finished.')

--- a/node_cli/fair/common.py
+++ b/node_cli/fair/common.py
@@ -83,7 +83,11 @@ def init(
 def cleanup(node_mode: NodeMode, prune: bool = False) -> None:
     node_mode = upsert_node_mode(node_mode=node_mode)
     env = compose_node_env(
-        SKALE_DIR_ENV_FILEPATH, save=False, node_type=NodeType.FAIR, node_mode=node_mode
+        SKALE_DIR_ENV_FILEPATH,
+        save=False,
+        node_type=NodeType.FAIR,
+        node_mode=node_mode,
+        skip_usr_conf_validation=True,
     )
     cleanup_fair_op(node_mode=node_mode, env=env, prune=prune)
     logger.info('Fair node was cleaned up, all containers and data removed')

--- a/node_cli/fair/common.py
+++ b/node_cli/fair/common.py
@@ -22,7 +22,6 @@ import time
 
 from node_cli.configs import INIT_TIMEOUT, SKALE_DIR, TM_INIT_TIMEOUT
 from node_cli.configs.user import SKALE_DIR_ENV_FILEPATH
-from node_cli.core.docker_config import cleanup_docker_configuration
 from node_cli.core.host import save_env_params
 from node_cli.core.node import compose_node_env, is_base_containers_alive
 from node_cli.core.node_options import upsert_node_mode

--- a/node_cli/fair/common.py
+++ b/node_cli/fair/common.py
@@ -87,7 +87,7 @@ def cleanup(node_mode: NodeMode, prune: bool = False) -> None:
         save=False,
         node_type=NodeType.FAIR,
         node_mode=node_mode,
-        skip_usr_conf_validation=True,
+        skip_user_conf_validation=True,
     )
     cleanup_fair_op(node_mode=node_mode, env=env, prune=prune)
     logger.info('Fair node was cleaned up, all containers and data removed')

--- a/node_cli/fair/common.py
+++ b/node_cli/fair/common.py
@@ -81,14 +81,13 @@ def init(
 
 
 @check_user
-def cleanup(node_mode: NodeMode) -> None:
+def cleanup(node_mode: NodeMode, prune: bool = False) -> None:
     node_mode = upsert_node_mode(node_mode=node_mode)
     env = compose_node_env(
         SKALE_DIR_ENV_FILEPATH, save=False, node_type=NodeType.FAIR, node_mode=node_mode
     )
-    cleanup_fair_op(node_mode=node_mode, env=env)
+    cleanup_fair_op(node_mode=node_mode, env=env, prune=prune)
     logger.info('Fair node was cleaned up, all containers and data removed')
-    cleanup_docker_configuration()
 
 
 @check_inited

--- a/node_cli/operations/__init__.py
+++ b/node_cli/operations/__init__.py
@@ -27,7 +27,7 @@ from node_cli.operations.base import (  # noqa
     turn_off as turn_off_op,
     turn_on as turn_on_op,
     restore as restore_op,
-    cleanup_passive as cleanup_passive_op,
+    cleanup as cleanup_skale_op,
     configure_nftables,
 )
 from node_cli.operations.fair import (  # noqa

--- a/node_cli/operations/base.py
+++ b/node_cli/operations/base.py
@@ -72,7 +72,7 @@ from node_cli.utils.docker_utils import (
     remove_dynamic_containers,
     system_prune,
 )
-from node_cli.utils.helper import cleanup_dir_content, rm_dir, str_to_bool, run_cmd
+from node_cli.utils.helper import cleanup_dir_content, rm_dir, str_to_bool
 from node_cli.utils.meta import CliMetaManager, FairCliMetaManager
 from node_cli.utils.node_type import NodeMode, NodeType
 from node_cli.utils.print_formatters import print_failed_requirements_checks

--- a/node_cli/operations/base.py
+++ b/node_cli/operations/base.py
@@ -49,6 +49,7 @@ from node_cli.core.node_options import (
 )
 from node_cli.core.resources import init_shared_space_volume, update_resource_allocation
 from node_cli.core.schains import (
+    cleanup_lvm_datadir,
     cleanup_no_lvm_datadir,
     update_node_cli_schain_status,
 )
@@ -442,17 +443,6 @@ def cleanup_passive(env, schain_name: str) -> None:
     rm_dir(SKALE_DIR)
 
 
-def cleanup_active():
-    logger.info('Starting cleanup for active node...')
-    logger.info('Unmounting /mnt/schains-shared-space...')
-    run_cmd(['sudo', 'umount', '/mnt/schains-shared-space'], check_code=False)
-    logger.info('Cleaning up /mnt directory content...')
-    cleanup_dir_content('/mnt/')
-    logger.info('Removing LVM volume group "schains"...')
-    run_cmd(['sudo', 'lvremove', '-f', 'schains'], check_code=False)
-    logger.info('Active node cleanup finished.')
-
-
 def cleanup(node_mode: NodeMode, env: dict, prune: bool = False) -> None:
     turn_off(env, node_type=NodeType.SKALE, node_mode=node_mode)
     if prune:
@@ -461,7 +451,7 @@ def cleanup(node_mode: NodeMode, env: dict, prune: bool = False) -> None:
         schain_name = env['SCHAIN_NAME']
         cleanup_no_lvm_datadir(chain_name=schain_name)
     else:
-        cleanup_active()
+        cleanup_lvm_datadir()
     rm_dir(GLOBAL_SKALE_DIR)
     rm_dir(SKALE_DIR)
     cleanup_dir_content(NFTABLES_CHAIN_FOLDER_PATH)

--- a/node_cli/operations/base.py
+++ b/node_cli/operations/base.py
@@ -29,11 +29,12 @@ from node_cli.configs import (
     CONTAINER_CONFIG_PATH,
     CONTAINER_CONFIG_TMP_PATH,
     GLOBAL_SKALE_DIR,
+    NFTABLES_CHAIN_FOLDER_PATH,
     SKALE_DIR,
 )
 from node_cli.core.checks import CheckType
 from node_cli.core.checks import run_checks as run_host_checks
-from node_cli.core.docker_config import configure_docker
+from node_cli.core.docker_config import cleanup_docker_configuration, configure_docker
 from node_cli.core.host import (
     ensure_btrfs_kernel_module_autoloaded,
     link_env_file,
@@ -69,7 +70,7 @@ from node_cli.utils.docker_utils import (
     docker_cleanup,
     remove_dynamic_containers,
 )
-from node_cli.utils.helper import rm_dir, str_to_bool
+from node_cli.utils.helper import cleanup_dir_content, rm_dir, str_to_bool
 from node_cli.utils.meta import CliMetaManager, FairCliMetaManager
 from node_cli.utils.node_type import NodeType, NodeMode
 from node_cli.utils.print_formatters import print_failed_requirements_checks
@@ -438,8 +439,18 @@ def restore(env, backup_path, node_type: NodeType, config_only=False):
     return True
 
 
-def cleanup_passive(env, schain_name: str) -> None:
-    turn_off(env, node_type=NodeType.SKALE, node_mode=NodeMode.PASSIVE)
-    cleanup_no_lvm_datadir(chain_name=schain_name)
+def cleanup_active():
+    pass
+
+
+def cleanup(node_mode: NodeMode, env: dict) -> None:
+    turn_off(env, node_type=NodeType.SKALE, node_mode=node_mode)
+    if node_mode == NodeMode.PASSIVE:
+        schain_name = env['SCHAIN_NAME']
+        cleanup_no_lvm_datadir(chain_name=schain_name)
+    else:
+        cleanup_active()
     rm_dir(GLOBAL_SKALE_DIR)
     rm_dir(SKALE_DIR)
+    cleanup_dir_content(NFTABLES_CHAIN_FOLDER_PATH)
+    cleanup_docker_configuration()

--- a/node_cli/operations/base.py
+++ b/node_cli/operations/base.py
@@ -69,6 +69,7 @@ from node_cli.utils.docker_utils import (
     compose_up,
     docker_cleanup,
     remove_dynamic_containers,
+    system_prune,
 )
 from node_cli.utils.helper import cleanup_dir_content, rm_dir, str_to_bool, run_cmd
 from node_cli.utils.meta import CliMetaManager, FairCliMetaManager
@@ -457,8 +458,10 @@ def cleanup_active():
     logger.info('Active node cleanup finished.')
 
 
-def cleanup(node_mode: NodeMode, env: dict) -> None:
+def cleanup(node_mode: NodeMode, env: dict, prune: bool = False) -> None:
     turn_off(env, node_type=NodeType.SKALE, node_mode=node_mode)
+    if prune:
+        system_prune()
     if node_mode == NodeMode.PASSIVE:
         schain_name = env['SCHAIN_NAME']
         cleanup_no_lvm_datadir(chain_name=schain_name)

--- a/node_cli/operations/base.py
+++ b/node_cli/operations/base.py
@@ -70,9 +70,9 @@ from node_cli.utils.docker_utils import (
     docker_cleanup,
     remove_dynamic_containers,
 )
-from node_cli.utils.helper import cleanup_dir_content, rm_dir, str_to_bool
+from node_cli.utils.helper import cleanup_dir_content, rm_dir, str_to_bool, run_cmd
 from node_cli.utils.meta import CliMetaManager, FairCliMetaManager
-from node_cli.utils.node_type import NodeType, NodeMode
+from node_cli.utils.node_type import NodeMode, NodeType
 from node_cli.utils.print_formatters import print_failed_requirements_checks
 
 logger = logging.getLogger(__name__)
@@ -439,8 +439,22 @@ def restore(env, backup_path, node_type: NodeType, config_only=False):
     return True
 
 
+def cleanup_passive(env, schain_name: str) -> None:
+    turn_off(env, node_type=NodeType.SKALE, node_mode=NodeMode.PASSIVE)
+    cleanup_no_lvm_datadir(chain_name=schain_name)
+    rm_dir(GLOBAL_SKALE_DIR)
+    rm_dir(SKALE_DIR)
+
+
 def cleanup_active():
-    pass
+    logger.info('Starting cleanup for active node...')
+    logger.info('Unmounting /mnt/schains-shared-space...')
+    run_cmd(['sudo', 'umount', '/mnt/schains-shared-space'], check_code=False)
+    logger.info('Cleaning up /mnt directory content...')
+    cleanup_dir_content('/mnt/')
+    logger.info('Removing LVM volume group "schains"...')
+    run_cmd(['sudo', 'lvremove', '-f', 'schains'], check_code=False)
+    logger.info('Active node cleanup finished.')
 
 
 def cleanup(node_mode: NodeMode, env: dict) -> None:

--- a/node_cli/operations/base.py
+++ b/node_cli/operations/base.py
@@ -114,8 +114,8 @@ def checked_host(func):
 
 
 @checked_host
-def update(env_filepath: str, env: Dict, node_type: NodeType, node_mode: NodeMode) -> bool:
-    compose_rm(node_type=node_type, node_mode=node_mode, env=env)
+def update(env_filepath: str, env: Dict, node_mode: NodeMode) -> bool:
+    compose_rm(node_type=NodeType.SKALE, node_mode=node_mode, env=env)
     remove_dynamic_containers()
 
     sync_skale_node()
@@ -151,8 +151,8 @@ def update(env_filepath: str, env: Dict, node_type: NodeType, node_mode: NodeMod
         distro.id(),
         distro.version(),
     )
-    update_images(env=env, node_type=node_type, node_mode=node_mode)
-    compose_up(env=env, node_type=node_type, node_mode=node_mode)
+    update_images(env=env, node_type=NodeType.SKALE, node_mode=node_mode)
+    compose_up(env=env, node_type=NodeType.SKALE, node_mode=node_mode)
     return True
 
 
@@ -199,7 +199,7 @@ def update_fair_boot(env_filepath: str, env: Dict, node_mode: NodeMode = NodeMod
 
 
 @checked_host
-def init(env_filepath: str, env: dict, node_type: NodeType, node_mode: NodeMode) -> None:
+def init(env_filepath: str, env: dict, node_mode: NodeMode) -> None:
     sync_skale_node()
     ensure_btrfs_kernel_module_autoloaded()
     if env.get('SKIP_DOCKER_CONFIG') != 'True':
@@ -229,9 +229,8 @@ def init(env_filepath: str, env: dict, node_type: NodeType, node_mode: NodeMode)
         distro.version(),
     )
     update_resource_allocation(env_type=env['ENV_TYPE'])
-    update_images(env=env, node_type=node_type, node_mode=node_mode)
-
-    compose_up(env=env, node_type=node_type, node_mode=node_mode)
+    update_images(env=env, node_type=NodeType.SKALE, node_mode=node_mode)
+    compose_up(env=env, node_type=NodeType.SKALE, node_mode=node_mode)
 
 
 @checked_host
@@ -370,11 +369,7 @@ def turn_on(env: dict, node_type: NodeType, node_mode: NodeMode) -> None:
     else:
         meta_manager = CliMetaManager()
         meta_manager.update_meta(
-            VERSION,
-            env['NODE_VERSION'],
-            env['DOCKER_LVMPY_VERSION'],
-            distro.id(),
-            distro.version()
+            VERSION, env['NODE_VERSION'], env['DOCKER_LVMPY_VERSION'], distro.id(), distro.version()
         )
     if env.get('SKIP_DOCKER_CONFIG') != 'True':
         configure_docker()

--- a/node_cli/operations/fair.py
+++ b/node_cli/operations/fair.py
@@ -63,6 +63,7 @@ from node_cli.utils.docker_utils import (
     remove_dynamic_containers,
     start_container_by_name,
     stop_container_by_name,
+    system_prune,
     wait_for_container,
 )
 from node_cli.utils.helper import cleanup_dir_content, rm_dir, str_to_bool
@@ -282,8 +283,10 @@ def restore(node_mode: NodeMode, env, backup_path, config_only=False):
     return True
 
 
-def cleanup(node_mode: NodeMode, env: dict) -> None:
+def cleanup(node_mode: NodeMode, env: dict, prune: bool = False) -> None:
     turn_off(env, node_type=NodeType.FAIR, node_mode=node_mode)
+    if prune:
+        system_prune()
     cleanup_no_lvm_datadir()
     rm_dir(GLOBAL_SKALE_DIR)
     rm_dir(SKALE_DIR)

--- a/tests/cli/fair_cli_test.py
+++ b/tests/cli/fair_cli_test.py
@@ -117,7 +117,7 @@ def test_fair_node_exit(mock_exit_core):
     mock_exit_core.assert_called_once()
 
 
-def test_cleanup_node(mocked_g_config):
+def test_cleanup_node(mocked_g_config, inited_node):
     pathlib.Path(SKALE_DIR).mkdir(parents=True, exist_ok=True)
 
     with (

--- a/tests/cli/fair_cli_test.py
+++ b/tests/cli/fair_cli_test.py
@@ -2,7 +2,6 @@ import pathlib
 from unittest import mock
 
 from click.testing import CliRunner
-
 from node_cli.cli.fair_boot import (
     init_boot,
     register_boot,
@@ -10,11 +9,16 @@ from node_cli.cli.fair_boot import (
 )
 from node_cli.cli.fair_node import (
     backup_node,
+    cleanup_node,
     migrate_node,
     exit_node,
     restore_node,
 )
-
+from node_cli.configs import SKALE_DIR
+from node_cli.utils.node_type import NodeMode
+from node_cli.utils.meta import CliMeta
+from tests.helper import run_command, subprocess_run_mock
+from tests.resources_test import BIG_DISK_SIZE
 
 @mock.patch('node_cli.cli.fair_node.restore_fair')
 def test_fair_node_restore(mock_restore_core, valid_env_file, tmp_path):
@@ -111,3 +115,25 @@ def test_fair_node_exit(mock_exit_core):
 
     assert result.exit_code == 0, f'Output: {result.output}\nException: {result.exception}'
     mock_exit_core.assert_called_once()
+
+
+def test_cleanup_node(mocked_g_config):
+    pathlib.Path(SKALE_DIR).mkdir(parents=True, exist_ok=True)
+
+    with (
+        mock.patch('subprocess.run', new=subprocess_run_mock),
+        mock.patch('node_cli.fair.common.cleanup_fair_op') as cleanup_mock,
+        mock.patch('node_cli.core.node.is_base_containers_alive', return_value=True),
+        mock.patch('node_cli.core.resources.get_disk_size', return_value=BIG_DISK_SIZE),
+        mock.patch('node_cli.operations.base.configure_nftables'),
+        mock.patch('node_cli.utils.decorators.is_node_inited', return_value=True),
+        mock.patch('node_cli.fair.common.compose_node_env', return_value={'SCHAIN_NAME': 'test'}),
+        mock.patch(
+            'node_cli.core.node.CliMetaManager.get_meta_info',
+            return_value=CliMeta(version='2.6.0', config_stream='3.0.2'),
+        ),
+    ):
+        result = run_command(cleanup_node, ['--yes'])
+        assert result.exit_code == 0
+        cleanup_mock.assert_called_once_with(
+            node_mode=NodeMode.ACTIVE, prune=False, env={'SCHAIN_NAME': 'test'})

--- a/tests/cli/fair_passive_node_test.py
+++ b/tests/cli/fair_passive_node_test.py
@@ -3,9 +3,11 @@ import pathlib
 
 import mock
 
-from node_cli.cli.passive_fair_node import init_passive_node, update_node
+from node_cli.cli.passive_fair_node import cleanup_node, init_passive_node, update_node
 from node_cli.configs import NODE_DATA_PATH, SKALE_DIR
 from node_cli.utils.helper import init_default_logger
+from node_cli.utils.meta import CliMeta
+from node_cli.utils.node_type import NodeMode
 from tests.helper import run_command, subprocess_run_mock
 from tests.resources_test import BIG_DISK_SIZE
 
@@ -84,3 +86,25 @@ def test_update_fair_passive(mocked_g_config, tmp_path):
     ):
         result = run_command(update_node, [env_file.as_posix(), '--yes'])
         assert result.exit_code == 0
+
+
+def test_cleanup_node(mocked_g_config):
+    pathlib.Path(SKALE_DIR).mkdir(parents=True, exist_ok=True)
+
+    with (
+        mock.patch('subprocess.run', new=subprocess_run_mock),
+        mock.patch('node_cli.fair.common.cleanup_fair_op') as cleanup_mock,
+        mock.patch('node_cli.core.node.is_base_containers_alive', return_value=True),
+        mock.patch('node_cli.core.resources.get_disk_size', return_value=BIG_DISK_SIZE),
+        mock.patch('node_cli.operations.base.configure_nftables'),
+        mock.patch('node_cli.utils.decorators.is_node_inited', return_value=True),
+        mock.patch('node_cli.fair.common.compose_node_env', return_value={'SCHAIN_NAME': 'test'}),
+        mock.patch(
+            'node_cli.core.node.CliMetaManager.get_meta_info',
+            return_value=CliMeta(version='2.6.0', config_stream='3.0.2'),
+        ),
+    ):
+        result = run_command(cleanup_node, ['--yes'])
+        assert result.exit_code == 0
+        cleanup_mock.assert_called_once_with(
+            node_mode=NodeMode.PASSIVE, prune=False, env={'SCHAIN_NAME': 'test'})

--- a/tests/cli/fair_passive_node_test.py
+++ b/tests/cli/fair_passive_node_test.py
@@ -71,7 +71,7 @@ def test_init_fair_passive_snapshot_any(mocked_g_config, tmp_path):
         assert result.exit_code == 0
 
 
-def test_update_fair_passive(mocked_g_config, tmp_path):
+def test_update_fair_passive(mocked_g_config, tmp_path, clean_node_options):
     env_file = tmp_path / 'test-env'
     env_file.write_text('')
     pathlib.Path(NODE_DATA_PATH).mkdir(parents=True, exist_ok=True)

--- a/tests/cli/node_test.py
+++ b/tests/cli/node_test.py
@@ -30,6 +30,7 @@ from node_cli.cli.node import (
     _turn_off,
     _turn_on,
     backup_node,
+    cleanup_node,
     node_info,
     register_node,
     remove_node_from_maintenance,
@@ -473,3 +474,23 @@ def test_node_version(meta_file_v2):
             result.output
             == "{'version': '0.1.1', 'config_stream': 'develop', 'docker_lvmpy_version': '1.1.2'}\n"
         )
+
+def test_cleanup_node(mocked_g_config):
+    pathlib.Path(SKALE_DIR).mkdir(parents=True, exist_ok=True)
+
+    with (
+        mock.patch('subprocess.run', new=subprocess_run_mock),
+        mock.patch('node_cli.core.node.cleanup_skale_op') as cleanup_mock,
+        mock.patch('node_cli.core.node.is_base_containers_alive', return_value=True),
+        mock.patch('node_cli.core.resources.get_disk_size', return_value=BIG_DISK_SIZE),
+        mock.patch('node_cli.operations.base.configure_nftables'),
+        mock.patch('node_cli.utils.decorators.is_node_inited', return_value=True),
+        mock.patch('node_cli.core.node.compose_node_env', return_value={}),
+        mock.patch(
+            'node_cli.core.node.CliMetaManager.get_meta_info',
+            return_value=CliMeta(version='2.6.0', config_stream='3.0.2'),
+        ),
+    ):
+        result = run_command(cleanup_node, ['--yes'])
+        assert result.exit_code == 0
+        cleanup_mock.assert_called_once_with(node_mode=NodeMode.ACTIVE, prune=False, env={})

--- a/tests/cli/passive_node_test.py
+++ b/tests/cli/passive_node_test.py
@@ -22,12 +22,12 @@ import pathlib
 
 import mock
 
-from node_cli.cli.passive_node import _cleanup_passive, _init_passive, _update_passive
+from node_cli.cli.passive_node import cleanup_node, _init_passive, _update_passive
 from node_cli.configs import NODE_DATA_PATH, SKALE_DIR
 from node_cli.core.node_options import NodeOptions
 from node_cli.utils.helper import init_default_logger
 from node_cli.utils.meta import CliMeta
-from node_cli.utils.node_type import NodeType
+from node_cli.utils.node_type import NodeType, NodeMode
 from tests.conftest import set_env_var
 from tests.helper import run_command, subprocess_run_mock
 from tests.resources_test import BIG_DISK_SIZE
@@ -127,12 +127,12 @@ def test_update_passive(passive_user_conf, mocked_g_config):
         assert result.exit_code == 0
 
 
-def test_cleanup_passive(mocked_g_config):
+def test_cleanup_node(mocked_g_config):
     pathlib.Path(SKALE_DIR).mkdir(parents=True, exist_ok=True)
 
     with (
         mock.patch('subprocess.run', new=subprocess_run_mock),
-        mock.patch('node_cli.core.node.cleanup_passive_op'),
+        mock.patch('node_cli.core.node.cleanup_skale_op') as cleanup_mock,
         mock.patch('node_cli.core.node.is_base_containers_alive', return_value=True),
         mock.patch('node_cli.core.resources.get_disk_size', return_value=BIG_DISK_SIZE),
         mock.patch('node_cli.operations.base.configure_nftables'),
@@ -143,5 +143,6 @@ def test_cleanup_passive(mocked_g_config):
             return_value=CliMeta(version='2.6.0', config_stream='3.0.2'),
         ),
     ):
-        result = run_command(_cleanup_passive, ['--yes'])
+        result = run_command(cleanup_node, ['--yes'])
         assert result.exit_code == 0
+        cleanup_mock.assert_called_once_with(node_mode=NodeMode.PASSIVE, prune=False, env={'SCHAIN_NAME': 'test'})

--- a/tests/cli/passive_node_test.py
+++ b/tests/cli/passive_node_test.py
@@ -145,4 +145,5 @@ def test_cleanup_node(mocked_g_config):
     ):
         result = run_command(cleanup_node, ['--yes'])
         assert result.exit_code == 0
-        cleanup_mock.assert_called_once_with(node_mode=NodeMode.PASSIVE, prune=False, env={'SCHAIN_NAME': 'test'})
+        cleanup_mock.assert_called_once_with(
+            node_mode=NodeMode.PASSIVE, prune=False, env={'SCHAIN_NAME': 'test'})

--- a/tests/core/core_node_test.py
+++ b/tests/core/core_node_test.py
@@ -12,7 +12,9 @@ import requests
 
 from node_cli.configs import NODE_DATA_PATH, SCHAINS_MNT_DIR_REGULAR, SCHAINS_MNT_DIR_SINGLE_CHAIN
 from node_cli.configs.resource_allocation import RESOURCE_ALLOCATION_FILEPATH
+from node_cli.configs.user import SKALE_DIR_ENV_FILEPATH
 from node_cli.core.node import (
+    cleanup,
     compose_node_env,
     get_expected_container_names,
     init,
@@ -471,3 +473,32 @@ def test_is_update_safe_when_api_call_fails(
     mock_requests_get.side_effect = requests.exceptions.ConnectionError('Test connection error')
     assert is_update_safe(node_mode=node_mode) is False
     mock_requests_get.assert_called_once()
+
+
+@mock.patch('node_cli.utils.decorators.is_user_valid', return_value=True)
+@mock.patch('node_cli.utils.decorators.is_node_inited', return_value=True)
+@mock.patch('node_cli.core.node.cleanup_skale_op')
+@mock.patch('node_cli.core.node.compose_node_env')
+def test_cleanup_success(
+    mock_compose_env,
+    mock_cleanup_skale_op,
+    mock_node_inited,
+    mock_is_user_valid,
+    inited_node,
+    resource_alloc,
+    meta_file_v3,
+    active_node_option,
+):
+    mock_env = {'ENV_TYPE': 'devnet'}
+    mock_compose_env.return_value = mock_env
+
+    cleanup(node_mode=NodeMode.ACTIVE)
+
+    mock_compose_env.assert_called_once_with(
+        SKALE_DIR_ENV_FILEPATH,
+        save=False,
+        node_type=NodeType.SKALE,
+        node_mode=NodeMode.ACTIVE,
+    )
+    mock_cleanup_skale_op.assert_called_once_with(
+        node_mode=NodeMode.ACTIVE, env=mock_env, prune=False)

--- a/tests/core/core_node_test.py
+++ b/tests/core/core_node_test.py
@@ -497,7 +497,7 @@ def test_cleanup_success(
         save=False,
         node_type=NodeType.SKALE,
         node_mode=NodeMode.ACTIVE,
-        skip_usr_conf_validation=True,
+        skip_user_conf_validation=True,
     )
     mock_cleanup_skale_op.assert_called_once_with(
         node_mode=NodeMode.ACTIVE, env=mock_env, prune=False)

--- a/tests/core/core_node_test.py
+++ b/tests/core/core_node_test.py
@@ -476,13 +476,11 @@ def test_is_update_safe_when_api_call_fails(
 
 
 @mock.patch('node_cli.utils.decorators.is_user_valid', return_value=True)
-@mock.patch('node_cli.utils.decorators.is_node_inited', return_value=True)
 @mock.patch('node_cli.core.node.cleanup_skale_op')
 @mock.patch('node_cli.core.node.compose_node_env')
 def test_cleanup_success(
     mock_compose_env,
     mock_cleanup_skale_op,
-    mock_node_inited,
     mock_is_user_valid,
     inited_node,
     resource_alloc,

--- a/tests/core/core_node_test.py
+++ b/tests/core/core_node_test.py
@@ -497,6 +497,7 @@ def test_cleanup_success(
         save=False,
         node_type=NodeType.SKALE,
         node_mode=NodeMode.ACTIVE,
+        skip_usr_conf_validation=True,
     )
     mock_cleanup_skale_op.assert_called_once_with(
         node_mode=NodeMode.ACTIVE, env=mock_env, prune=False)

--- a/tests/core/core_schains_test.py
+++ b/tests/core/core_schains_test.py
@@ -80,6 +80,9 @@ def test_cleanup_passive_datadir(tmp_passive_datadir):
             hash_path = snapshot_folder.joinpath('snapshot_hash.txt')
             hash_path.touch()
 
-    with mock.patch('node_cli.core.schains.rm_btrfs_subvolume'):
+    with (
+        mock.patch('node_cli.core.schains.rm_btrfs_subvolume'),
+        mock.patch('node_cli.core.schains.run_cmd'),
+    ):
         cleanup_no_lvm_datadir(schain_name, base_path=tmp_passive_datadir)
         assert not os.path.isdir(base_folder)

--- a/tests/fair/fair_node_test.py
+++ b/tests/fair/fair_node_test.py
@@ -179,7 +179,7 @@ def test_cleanup_success(
         save=False,
         node_type=NodeType.FAIR,
         node_mode=NodeMode.ACTIVE,
-        skip_usr_conf_validation=True,
+        skip_user_conf_validation=True,
     )
     mock_cleanup_fair_op.assert_called_once_with(
         node_mode=NodeMode.ACTIVE, env=mock_env, prune=False)
@@ -214,7 +214,7 @@ def test_cleanup_calls_operations_in_correct_order(
             save=False,
             node_type=mock.ANY,
             node_mode=NodeMode.ACTIVE,
-            skip_usr_conf_validation=True),
+            skip_user_conf_validation=True),
         mock.call.cleanup_fair_op(node_mode=NodeMode.ACTIVE, env=mock_env, prune=False),
     ]
     manager.assert_has_calls(expected_calls, any_order=False)

--- a/tests/fair/fair_node_test.py
+++ b/tests/fair/fair_node_test.py
@@ -179,6 +179,7 @@ def test_cleanup_success(
         save=False,
         node_type=NodeType.FAIR,
         node_mode=NodeMode.ACTIVE,
+        skip_usr_conf_validation=True,
     )
     mock_cleanup_fair_op.assert_called_once_with(
         node_mode=NodeMode.ACTIVE, env=mock_env, prune=False)
@@ -208,7 +209,12 @@ def test_cleanup_calls_operations_in_correct_order(
     cleanup(node_mode=NodeMode.ACTIVE)
 
     expected_calls = [
-        mock.call.compose_env(mock.ANY, save=False, node_type=mock.ANY, node_mode=NodeMode.ACTIVE),
+        mock.call.compose_env(
+            mock.ANY,
+            save=False,
+            node_type=mock.ANY,
+            node_mode=NodeMode.ACTIVE,
+            skip_usr_conf_validation=True),
         mock.call.cleanup_fair_op(node_mode=NodeMode.ACTIVE, env=mock_env, prune=False),
     ]
     manager.assert_has_calls(expected_calls, any_order=False)

--- a/tests/fair/fair_node_test.py
+++ b/tests/fair/fair_node_test.py
@@ -158,13 +158,11 @@ def test_migrate_from_boot(
 
 
 @mock.patch('node_cli.utils.decorators.is_user_valid', return_value=True)
-@mock.patch('node_cli.fair.common.cleanup_docker_configuration')
 @mock.patch('node_cli.fair.common.cleanup_fair_op')
 @mock.patch('node_cli.fair.common.compose_node_env')
 def test_cleanup_success(
     mock_compose_env,
     mock_cleanup_fair_op,
-    mock_cleanup_docker_config,
     mock_is_user_valid,
     inited_node,
     resource_alloc,
@@ -182,18 +180,16 @@ def test_cleanup_success(
         node_type=NodeType.FAIR,
         node_mode=NodeMode.ACTIVE,
     )
-    mock_cleanup_fair_op.assert_called_once_with(node_mode=NodeMode.ACTIVE, env=mock_env)
-    mock_cleanup_docker_config.assert_called_once()
+    mock_cleanup_fair_op.assert_called_once_with(
+        node_mode=NodeMode.ACTIVE, env=mock_env, prune=False)
 
 
 @mock.patch('node_cli.utils.decorators.is_user_valid', return_value=True)
-@mock.patch('node_cli.fair.common.cleanup_docker_configuration')
 @mock.patch('node_cli.fair.common.cleanup_fair_op')
 @mock.patch('node_cli.fair.common.compose_node_env')
 def test_cleanup_calls_operations_in_correct_order(
     mock_compose_env,
     mock_cleanup_fair_op,
-    mock_cleanup_docker_config,
     mock_is_user_valid,
     inited_node,
     resource_alloc,
@@ -208,26 +204,22 @@ def test_cleanup_calls_operations_in_correct_order(
     manager = mock.Mock()
     manager.attach_mock(mock_compose_env, 'compose_env')
     manager.attach_mock(mock_cleanup_fair_op, 'cleanup_fair_op')
-    manager.attach_mock(mock_cleanup_docker_config, 'cleanup_docker_config')
 
     cleanup(node_mode=NodeMode.ACTIVE)
 
     expected_calls = [
         mock.call.compose_env(mock.ANY, save=False, node_type=mock.ANY, node_mode=NodeMode.ACTIVE),
-        mock.call.cleanup_fair_op(node_mode=NodeMode.ACTIVE, env=mock_env),
-        mock.call.cleanup_docker_config(),
+        mock.call.cleanup_fair_op(node_mode=NodeMode.ACTIVE, env=mock_env, prune=False),
     ]
     manager.assert_has_calls(expected_calls, any_order=False)
 
 
 @mock.patch('node_cli.utils.decorators.is_user_valid', return_value=True)
-@mock.patch('node_cli.fair.common.cleanup_docker_configuration')
 @mock.patch('node_cli.fair.common.cleanup_fair_op', side_effect=Exception('Cleanup failed'))
 @mock.patch('node_cli.fair.common.compose_node_env')
 def test_cleanup_continues_after_fair_op_error(
     mock_compose_env,
     mock_cleanup_fair_op,
-    mock_cleanup_docker_config,
     mock_is_user_valid,
     inited_node,
     resource_alloc,
@@ -241,8 +233,8 @@ def test_cleanup_continues_after_fair_op_error(
         cleanup(node_mode=NodeMode.ACTIVE)
 
     mock_compose_env.assert_called_once()
-    mock_cleanup_fair_op.assert_called_once_with(node_mode=NodeMode.ACTIVE, env=mock_env)
-    mock_cleanup_docker_config.assert_not_called()
+    mock_cleanup_fair_op.assert_called_once_with(
+        node_mode=NodeMode.ACTIVE, env=mock_env, prune=False)
 
 
 @mock.patch('node_cli.utils.decorators.is_user_valid', return_value=False)
@@ -269,7 +261,6 @@ def test_cleanup_fails_when_not_inited(ensure_meta_removed, active_node_option):
 
 
 @mock.patch('node_cli.utils.decorators.is_user_valid', return_value=True)
-@mock.patch('node_cli.fair.common.cleanup_docker_configuration')
 @mock.patch('node_cli.fair.common.cleanup_fair_op')
 @mock.patch('node_cli.fair.common.compose_node_env')
 @mock.patch('node_cli.fair.common.logger')
@@ -277,7 +268,6 @@ def test_cleanup_logs_success_message(
     mock_logger,
     mock_compose_env,
     mock_cleanup_fair_op,
-    mock_cleanup_docker_config,
     mock_is_user_valid,
     inited_node,
     resource_alloc,


### PR DESCRIPTION
This pull request refactors and enhances the cleanup commands for both SKALE and FAIR nodes, improving consistency, user clarity, and functionality. The main changes include standardizing the cleanup interface, adding a `--prune` option to allow users to prune the Docker system, and consolidating cleanup logic for better maintainability. Several internal APIs and command descriptions have also been updated for clarity.

**Cleanup command improvements:**

* Standardized the `cleanup` command for SKALE and FAIR nodes to use consistent help text and prompts, and added a `--prune` flag to optionally prune the Docker system during cleanup. [[1]](diffhunk://#diff-2f82f30c374ab8a51e09163549a12b05544deb7793f40e09c028aa2457d91364L155-R166) [[2]](diffhunk://#diff-0abfa4dcd6a757f10dd86dba1bfc0d215e1f2244b5e2aa959b04ffa045afef6cR261-R274) [[3]](diffhunk://#diff-4c709cc566179479c162f75ac17db239204e4366e95e49237797e1c3096bf25dL108-R119) [[4]](diffhunk://#diff-c6dc109bf6aef2abe6a09d0cf57c793e52c86309f91346f67229d92f9ce5c539L75-R87)
* Refactored the cleanup logic for SKALE nodes to a unified `cleanup` function, supporting both active and passive node modes, and handling Docker pruning when requested. [[1]](diffhunk://#diff-cd8b3a0d0a5921ad426729c3dbcd0ae7a148dd6772be2cc807da4316dd166050L228-R239) [[2]](diffhunk://#diff-cd8b3a0d0a5921ad426729c3dbcd0ae7a148dd6772be2cc807da4316dd166050L160-R160) [[3]](diffhunk://#diff-cd8b3a0d0a5921ad426729c3dbcd0ae7a148dd6772be2cc807da4316dd166050R251-R259) [[4]](diffhunk://#diff-cd8b3a0d0a5921ad426729c3dbcd0ae7a148dd6772be2cc807da4316dd166050R268)

**Internal API and codebase consistency:**

* Updated function signatures and internal calls to remove unnecessary `node_type` parameters and ensure consistent use of `NodeMode` and `NodeType` enums across the codebase. [[1]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L117-R120) [[2]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L154-R157) [[3]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L202-R204) [[4]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653L232-R235)
* Renamed and consolidated imports and operation functions to reflect the unified cleanup logic, e.g., using `cleanup_skale` and `cleanup_skale_op`. [[1]](diffhunk://#diff-0abfa4dcd6a757f10dd86dba1bfc0d215e1f2244b5e2aa959b04ffa045afef6cR24) [[2]](diffhunk://#diff-cd8b3a0d0a5921ad426729c3dbcd0ae7a148dd6772be2cc807da4316dd166050L59-R59) [[3]](diffhunk://#diff-157eee07a01f717792863e3e58351c19450344388ee73aab3238025f98ee88a2L30-R30)

**Validation and environment handling:**

* Added a `skip_usr_conf_validation` parameter to user config and environment composition functions to bypass user config validation during cleanup, streamlining the process. [[1]](diffhunk://#diff-f3abb734bd46614e5fda5d5ba9785676d736559df41db30ba7e6a73747c578b6R146) [[2]](diffhunk://#diff-f3abb734bd46614e5fda5d5ba9785676d736559df41db30ba7e6a73747c578b6R164) [[3]](diffhunk://#diff-cd8b3a0d0a5921ad426729c3dbcd0ae7a148dd6772be2cc807da4316dd166050R251-R259) [[4]](diffhunk://#diff-cd8b3a0d0a5921ad426729c3dbcd0ae7a148dd6772be2cc807da4316dd166050R268)

**Low-level cleanup enhancements:**

* Improved the cleanup routines to ensure proper unmounting, removal of directories, and Docker configuration cleanup for both node types. [[1]](diffhunk://#diff-0e0b7382b96158cf25c4f92aebbe86caa7643e49389f357c64288832ea04b9a7L302-R304) [[2]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653R443-R468) [[3]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cL285-R289)

**Testing and imports:**

* Updated test imports and helper functions to support the new cleanup command structure and maintain test coverage.

These changes collectively make the node cleanup process clearer for users and easier to maintain and extend for developers.