### PR TITLE
Pull pre-merge changes from develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ SKALE Node CLI, part of the SKALE suite of validator tools, is the command line 
 
 * Prerequisites
 
-Ensure that the following package is installed: **docker**, **docker-compose** (1.27.4+)
+Ensure that the following package is installed: **docker**, **docker-compose**
 
 * Download the executable
 

--- a/node_cli/cli/__init__.py
+++ b/node_cli/cli/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.6.2'
+__version__ = '2.6.3'
 
 if __name__ == '__main__':
     print(__version__)

--- a/node_cli/core/ssl/check.py
+++ b/node_cli/core/ssl/check.py
@@ -201,8 +201,15 @@ def check_ssl_connection(host, port, silent=False):
     ]
     expose_output = not silent
     with detached_subprocess(ssl_check_cmd, expose_output=expose_output) as dp:
-        time.sleep(1)
-        code = dp.poll()
-        if code is not None:
+        for _ in range(10):
+            code = dp.poll()
+            if code is None:
+                logger.info('Healthcheck process still running...')
+                time.sleep(2)
+                continue
+            elif code == 0:
+                return
             logger.error('Healthcheck connection failed')
             raise SSLHealthcheckError('OpenSSL connection verification failed')
+        logger.error('Healthcheck timed-out')
+        raise SSLHealthcheckError('OpenSSL connection verification timed-out')

--- a/node_cli/core/ssl/check.py
+++ b/node_cli/core/ssl/check.py
@@ -20,6 +20,7 @@
 import time
 import socket
 import logging
+import subprocess
 from contextlib import contextmanager
 
 from node_cli.core.ssl.utils import detached_subprocess
@@ -201,15 +202,15 @@ def check_ssl_connection(host, port, silent=False):
     ]
     expose_output = not silent
     with detached_subprocess(ssl_check_cmd, expose_output=expose_output) as dp:
-        for _ in range(10):
-            code = dp.poll()
-            if code is None:
-                logger.info('Healthcheck process still running...')
-                time.sleep(2)
-                continue
-            elif code == 0:
-                return
-            logger.error('Healthcheck connection failed')
-            raise SSLHealthcheckError('OpenSSL connection verification failed')
-        logger.error('Healthcheck timed-out')
-        raise SSLHealthcheckError('OpenSSL connection verification timed-out')
+        timeout = 20
+        try:
+            dp.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            logger.error('Healthcheck timed-out after %s s', timeout)
+            raise SSLHealthcheckError('OpenSSL connection verification timed-out')
+
+        if dp.returncode == 0:  # success
+            return
+
+        logger.error('Healthcheck connection failed (code %s)', dp.returncode)
+        raise SSLHealthcheckError('OpenSSL connection verification failed')

--- a/node_cli/core/ssl/utils.py
+++ b/node_cli/core/ssl/utils.py
@@ -50,7 +50,7 @@ def detached_subprocess(cmd, expose_output=False):
     logger.debug(f'Starting detached subprocess: {cmd}')
     p = subprocess.Popen(
         cmd,
-        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL,
         encoding='utf-8'
     )
     try:


### PR DESCRIPTION
This pull request introduces improvements to the SSL health check logic in the SKALE Node CLI, enhancing reliability and error handling. The changes mainly focus on making the SSL connection verification process more robust and updating subprocess management.

### SSL Health Check Improvements

* The `check_ssl_connection` function now waits for the OpenSSL subprocess to finish with a timeout, raising a clear error if the check takes too long or fails, instead of relying on a fixed sleep and poll approach. This results in more reliable and informative error handling.
* The `subprocess` module is now explicitly imported in `node_cli/core/ssl/check.py` to support the new timeout logic.

### Subprocess Management

* The `detached_subprocess` function in `node_cli/core/ssl/utils.py` now sets `stdin=subprocess.DEVNULL` to prevent the subprocess from waiting for input, improving process isolation and avoiding potential hangs.

### Documentation

* The `README.md` was updated to remove the version restriction on `docker-compose`, clarifying that any version is acceptable.