### PR TITLE
Fix skale passive node options

### DIFF
--- a/node_cli/operations/base.py
+++ b/node_cli/operations/base.py
@@ -343,7 +343,7 @@ def update_passive(env_filepath: str, env: Dict) -> bool:
     meta_manager.update_meta(
         VERSION,
         env['NODE_VERSION'],
-        env['DOCKER_LVMPY_VERSION'],
+        None,
         distro.id(),
         distro.version(),
     )

--- a/node_cli/utils/docker_utils.py
+++ b/node_cli/utils/docker_utils.py
@@ -77,10 +77,7 @@ BASE_FAIR_BOOT_COMPOSE_SERVICES = {
     'boot-api': 'sk_boot_api',
 }
 
-BASE_PASSIVE_COMPOSE_SERVICES = {
-    'admin': 'sk_admin',
-    'nginx': 'sk_nginx',
-}
+BASE_PASSIVE_COMPOSE_SERVICES = {'admin': 'sk_admin', 'nginx': 'sk_nginx', **REDIS_SERVICE_DICT}
 
 BASE_PASSIVE_FAIR_COMPOSE_SERVICES = {
     'admin': 'sk_admin',

--- a/node_cli/utils/meta.py
+++ b/node_cli/utils/meta.py
@@ -26,7 +26,7 @@ class CliMetaBase(abc.ABC):
 
 @dataclass
 class CliMeta(CliMetaBase):
-    docker_lvmpy_version: str = DEFAULT_DOCKER_LVMPY_VERSION
+    docker_lvmpy_version: str | None = DEFAULT_DOCKER_LVMPY_VERSION
 
     def asdict(self) -> dict:
         return {


### PR DESCRIPTION
This pull request makes several updates to the passive node management logic, primarily focusing on how Docker service versions are handled and how service definitions are composed. The most significant changes involve removing the dependency on the `DOCKER_LVMPY_VERSION` environment variable for passive updates, updating the meta data structure to allow for `None` values, and streamlining the definition of passive compose services.

**Passive node update logic and metadata:**
- The `update_passive` function no longer sets the `DOCKER_LVMPY_VERSION` in the meta update, passing `None` instead. This removes the requirement for this environment variable during passive updates.
- The `CliMeta` dataclass now allows `docker_lvmpy_version` to be `None`, making the metadata structure more flexible and accommodating the above change.

**Docker compose service definitions:**
- The `BASE_PASSIVE_COMPOSE_SERVICES` dictionary now includes all items from `REDIS_SERVICE_DICT` in addition to the existing services, simplifying and centralizing service definitions.

**Submodule update:**
- The `helper-scripts` submodule has been updated to a new commit, likely bringing in upstream improvements or fixes.