### PR TITLE
Add `bite` field to SkaleUserConfig and PassiveSkaleUserConfig classes

### DIFF
--- a/node_cli/configs/user.py
+++ b/node_cli/configs/user.py
@@ -127,6 +127,7 @@ class SkaleUserConfig(BaseUserConfig):
     disable_dry_run: str = ''
     default_gas_limit: str = ''
     default_gas_price_wei: str = ''
+    bite: str = ''
 
 
 @dataclass
@@ -136,6 +137,7 @@ class PassiveSkaleUserConfig(BaseUserConfig):
     schain_name: str = ''
     ima_contracts: str = ''
     enforce_btrfs: str = ''
+    bite: str = ''
 
 
 def get_validated_user_config(


### PR DESCRIPTION
This pull request adds a new configuration field, `bite`, to both the `SkaleUserConfig` and `PassiveSkaleUserConfig` classes in `node_cli/configs/user.py`. This change ensures that both active and passive user configuration classes now support the `bite` attribute.

Configuration updates:

* Added a `bite` field of type `str` to the `SkaleUserConfig` class.
* Added a `bite` field of type `str` to the `PassiveSkaleUserConfig` class.