### PR TITLE
Fix internal settings generation

### DIFF
--- a/node_cli/core/node.py
+++ b/node_cli/core/node.py
@@ -87,7 +87,7 @@ from node_cli.utils.print_formatters import (
     print_node_cmd_error,
     print_node_info,
 )
-from node_cli.utils.settings import validate_and_save_node_settings
+from node_cli.utils.settings import save_internal_settings, validate_and_save_node_settings
 from skale_core.settings import get_settings
 from node_cli.utils.texts import safe_load_texts
 
@@ -154,6 +154,7 @@ def register_node(name, p2p_ip, public_ip, port, domain_name):
 @check_not_inited
 def init(config_file: str, node_type: NodeType) -> None:
     node_mode = NodeMode.ACTIVE
+    save_internal_settings(node_type=node_type, node_mode=node_mode)
     settings = validate_and_save_node_settings(config_file, node_type, node_mode)
     compose_env = compose_node_env(node_type=node_type, node_mode=node_mode)
 
@@ -281,6 +282,7 @@ def update(
     if (__version__ == 'test' or __version__.startswith('2.6')) and prev_version == '2.5.0':
         migrate_2_6()
     logger.info('Node update started')
+    save_internal_settings(node_type=node_type, node_mode=node_mode)
     settings = validate_and_save_node_settings(config_file, node_type, node_mode)
     compose_env = compose_node_env(node_type=node_type, node_mode=node_mode)
     update_ok = update_op(settings=settings, compose_env=compose_env, node_mode=node_mode)

--- a/node_cli/operations/base.py
+++ b/node_cli/operations/base.py
@@ -178,7 +178,6 @@ def init(settings: BaseNodeSettings, compose_env: dict, node_mode: NodeMode) -> 
     configure_nftables(enable_monitoring=settings.monitoring_containers)
 
     prepare_host(env_type=settings.env_type)
-    save_internal_settings(node_type=NodeType.SKALE, node_mode=node_mode)
 
     mark_active_node()
 


### PR DESCRIPTION
This pull request updates the node initialization and update workflows to ensure that internal settings are saved consistently when initializing or updating a node. The main change is to move the call to `save_internal_settings` from a lower-level operation to the higher-level CLI commands, ensuring settings are saved at the appropriate stage.

**Improvements to node initialization and update workflows:**

* The `save_internal_settings` function is now called at the start of both the `init` and `update` functions in `node_cli/core/node.py`, ensuring internal settings are saved before further configuration steps. [[1]](diffhunk://#diff-cd8b3a0d0a5921ad426729c3dbcd0ae7a148dd6772be2cc807da4316dd166050R157) [[2]](diffhunk://#diff-cd8b3a0d0a5921ad426729c3dbcd0ae7a148dd6772be2cc807da4316dd166050R285)
* The redundant call to `save_internal_settings` in `node_cli/operations/base.py` has been removed, centralizing responsibility for saving internal settings in the CLI layer.

**Imports and dependencies:**

* The import of `save_internal_settings` has been added to `node_cli/core/node.py` to support the above changes.