### PR TITLE
fix dynamic containers rm function after v4 migration

### DIFF
--- a/node_cli/utils/docker_utils.py
+++ b/node_cli/utils/docker_utils.py
@@ -125,26 +125,32 @@ def get_containers(container_name_filter=None, _all=True) -> list:
     return docker_client().containers.list(all=_all, filters=filters)
 
 
-def get_all_schain_containers(_all=True) -> list:
-    return docker_client().containers.list(all=_all, filters={'name': 'sk_skaled_*'})
+def get_all_skaled_containers(_all=True) -> list:
+    dc = docker_client()
+    return dc.containers.list(all=_all, filters={'name': 'sk_skaled_'}) + dc.containers.list(
+        all=_all, filters={'name': 'skale_schain_'}
+    )
 
 
 def get_all_ima_containers(_all=True) -> list:
-    return docker_client().containers.list(all=_all, filters={'name': 'sk_ima_*'})
+    dc = docker_client()
+    return dc.containers.list(all=_all, filters={'name': 'sk_ima_'}) + dc.containers.list(
+        all=_all, filters={'name': 'skale_ima_'}
+    )
 
 
 def remove_dynamic_containers() -> None:
-    logger.info('Removing sChains containers')
-    rm_all_schain_containers()
+    logger.info('Removing skaled containers')
+    rm_all_skaled_containers()
     logger.info('Removing IMA containers')
     rm_all_ima_containers()
     logger.info('Removing telegraf (if exists)')
     remove_telegraf()
 
 
-def rm_all_schain_containers():
-    schain_containers = get_all_schain_containers()
-    remove_containers(schain_containers, timeout=SCHAIN_REMOVE_TIMEOUT)
+def rm_all_skaled_containers():
+    skaled_containers = get_all_skaled_containers()
+    remove_containers(skaled_containers, timeout=SCHAIN_REMOVE_TIMEOUT)
 
 
 def rm_all_ima_containers():

--- a/tests/docker_utils_test.py
+++ b/tests/docker_utils_test.py
@@ -1,11 +1,18 @@
 import os
 import time
 from time import sleep
+from unittest.mock import MagicMock
 
 import mock
 import pytest
 
-from node_cli.utils.docker_utils import docker_cleanup, save_container_logs, safe_rm
+from node_cli.utils.docker_utils import (
+    docker_cleanup,
+    get_all_ima_containers,
+    get_all_skaled_containers,
+    save_container_logs,
+    safe_rm,
+)
 from node_cli.configs import REMOVED_CONTAINERS_FOLDER_PATH
 
 
@@ -95,3 +102,56 @@ def test_docker_cleanup(dclient, simple_container):
 
     with mock.patch('node_cli.utils.docker_utils.run_cmd', side_effect=ValueError):
         docker_cleanup(dclient=dclient)
+
+
+def _make_container(name: str) -> MagicMock:
+    c = MagicMock()
+    c.name = name
+    c.id = name
+    return c
+
+
+def test_get_all_skaled_containers_both_prefixes():
+    new_container = _make_container('sk_skaled_chain1')
+    legacy_container = _make_container('skale_schain_chain2')
+
+    def fake_list(all=True, filters=None):
+        prefix = filters['name']
+        if prefix == 'sk_skaled_':
+            return [new_container]
+        if prefix == 'skale_schain_':
+            return [legacy_container]
+        return []
+
+    mock_dc = MagicMock()
+    mock_dc.containers.list.side_effect = fake_list
+
+    with mock.patch('node_cli.utils.docker_utils.docker_client', return_value=mock_dc):
+        result = get_all_skaled_containers()
+
+    assert len(result) == 2
+    names = {c.name for c in result}
+    assert names == {'sk_skaled_chain1', 'skale_schain_chain2'}
+
+
+def test_get_all_ima_containers_both_prefixes():
+    new_container = _make_container('sk_ima_chain1')
+    legacy_container = _make_container('skale_ima_chain2')
+
+    def fake_list(all=True, filters=None):
+        prefix = filters['name']
+        if prefix == 'sk_ima_':
+            return [new_container]
+        if prefix == 'skale_ima_':
+            return [legacy_container]
+        return []
+
+    mock_dc = MagicMock()
+    mock_dc.containers.list.side_effect = fake_list
+
+    with mock.patch('node_cli.utils.docker_utils.docker_client', return_value=mock_dc):
+        result = get_all_ima_containers()
+
+    assert len(result) == 2
+    names = {c.name for c in result}
+    assert names == {'sk_ima_chain1', 'skale_ima_chain2'}


### PR DESCRIPTION
This pull request updates the logic for discovering and removing Docker containers related to "skaled" and "IMA" services, expanding support for both new and legacy container name prefixes. It also adds comprehensive tests to ensure both naming conventions are handled correctly.

**Docker container discovery and removal improvements:**

* Updated `get_all_skaled_containers` and `get_all_ima_containers` in `docker_utils.py` to return containers matching both the new (`sk_*`) and legacy (`skale_*`) name prefixes, ensuring compatibility with containers created under either convention.
* Renamed related functions and log messages from "schain" to "skaled" for clarity and consistency.

**Testing enhancements:**

* Added tests in `docker_utils_test.py` for `get_all_skaled_containers` and `get_all_ima_containers` to verify that both new and legacy prefixes are detected, using mocked Docker clients and containers. [[1]](diffhunk://#diff-3369c39b709dbc79564167921e05c8788bf5c804e4e99036c57eba069bbce584R4-R15) [[2]](diffhunk://#diff-3369c39b709dbc79564167921e05c8788bf5c804e4e99036c57eba069bbce584R105-R157)