### PR TITLE
Add internal settings generation for passive node

### DIFF
--- a/node_cli/core/node.py
+++ b/node_cli/core/node.py
@@ -201,6 +201,7 @@ def init_passive(
     config_file: str, indexer: bool, archive: bool, snapshot: bool, snapshot_from: Optional[str]
 ) -> None:
     node_mode = NodeMode.PASSIVE
+    save_internal_settings(node_type=NodeType.SKALE, node_mode=node_mode)
     settings = validate_and_save_node_settings(config_file, NodeType.SKALE, node_mode)
     compose_env = compose_node_env(node_type=NodeType.SKALE, node_mode=node_mode)
     init_passive_op(
@@ -225,6 +226,7 @@ def update_passive(config_file: str) -> None:
     prev_version = CliMetaManager().get_meta_info().version
     if (__version__ == 'test' or __version__.startswith('2.6')) and prev_version == '2.5.0':
         migrate_2_6()
+    save_internal_settings(node_type=NodeType.SKALE, node_mode=NodeMode.PASSIVE)
     settings = validate_and_save_node_settings(config_file, NodeType.SKALE, NodeMode.PASSIVE)
     compose_env = compose_node_env(node_type=NodeType.SKALE, node_mode=NodeMode.PASSIVE)
     update_ok = update_passive_op(settings=settings, compose_env=compose_env)


### PR DESCRIPTION
This pull request introduces an important update to the initialization and update processes for passive SKALE nodes. The main change ensures that internal settings are consistently saved whenever a passive node is initialized or updated, improving reliability and configuration management.

Configuration consistency improvements:

* Added a call to `save_internal_settings` in the `init_passive` function to ensure internal settings are saved when initializing a passive SKALE node.
* Added a call to `save_internal_settings` in the `update_passive` function to ensure internal settings are saved during passive node updates.