### PR TITLE
fix internal settings update

### DIFF
--- a/node_cli/core/node.py
+++ b/node_cli/core/node.py
@@ -177,6 +177,7 @@ def restore(
     config_only: bool = False,
 ):
     node_mode = NodeMode.ACTIVE
+    save_internal_settings(node_type=node_type, node_mode=node_mode)
     settings = validate_and_save_node_settings(config_file, node_type, node_mode)
     compose_env = compose_node_env(node_type=node_type, node_mode=node_mode)
 

--- a/node_cli/fair/active.py
+++ b/node_cli/fair/active.py
@@ -35,7 +35,7 @@ from node_cli.utils.exit_codes import CLIExitCodes
 from node_cli.utils.helper import error_exit, get_request, post_request
 from node_cli.utils.node_type import NodeMode, NodeType
 from node_cli.utils.print_formatters import print_node_cmd_error, print_node_info_fair
-from node_cli.utils.settings import validate_and_save_node_settings
+from node_cli.utils.settings import save_internal_settings, validate_and_save_node_settings
 from node_cli.utils.texts import safe_load_texts
 
 logger = logging.getLogger(__name__)
@@ -67,6 +67,7 @@ def migrate_from_boot(
     config_file: str,
 ) -> None:
     logger.info('Migrating from boot to fair node...')
+    save_internal_settings(node_type=NodeType.FAIR, node_mode=NodeMode.ACTIVE)
     settings = validate_and_save_node_settings(config_file, NodeType.FAIR, NodeMode.ACTIVE)
     compose_env = compose_node_env(node_type=NodeType.FAIR, node_mode=NodeMode.ACTIVE)
     migrate_ok = update_fair_op(
@@ -143,6 +144,7 @@ def exit() -> None:
 @check_not_inited
 def restore(backup_path: str, config_file: str, config_only: bool = False):
     node_mode = NodeMode.ACTIVE
+    save_internal_settings(node_type=NodeType.FAIR, node_mode=node_mode)
     settings = validate_and_save_node_settings(config_file, NodeType.FAIR, node_mode)
     compose_env = compose_node_env(node_type=NodeType.FAIR, node_mode=node_mode)
 

--- a/node_cli/fair/boot.py
+++ b/node_cli/fair/boot.py
@@ -30,7 +30,7 @@ from node_cli.utils.exit_codes import CLIExitCodes
 from node_cli.utils.helper import error_exit
 from node_cli.utils.node_type import NodeMode, NodeType
 from node_cli.utils.print_formatters import print_node_cmd_error
-from node_cli.utils.settings import validate_and_save_node_settings
+from node_cli.utils.settings import save_internal_settings, validate_and_save_node_settings
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 def init(config_file: str) -> None:
     node_mode = NodeMode.ACTIVE
     node_type = NodeType.FAIR
+    save_internal_settings(node_type=node_type, node_mode=node_mode)
     settings = validate_and_save_node_settings(config_file, node_type, node_mode)
     compose_env = compose_node_env(node_type=node_type, node_mode=node_mode)
 
@@ -55,6 +56,7 @@ def init(config_file: str) -> None:
 def update(config_file: str, pull_config_for_schain: str) -> None:
     logger.info('Fair boot node update started')
     node_mode = upsert_node_mode(node_mode=NodeMode.ACTIVE)
+    save_internal_settings(node_type=NodeType.FAIR, node_mode=node_mode)
     settings = validate_and_save_node_settings(config_file, NodeType.FAIR, node_mode)
     compose_env = compose_node_env(node_type=NodeType.FAIR, node_mode=node_mode)
     migrate_ok = update_fair_boot_op(

--- a/node_cli/fair/common.py
+++ b/node_cli/fair/common.py
@@ -38,7 +38,7 @@ from node_cli.utils.exit_codes import CLIExitCodes
 from node_cli.utils.helper import error_exit
 from node_cli.utils.node_type import NodeMode, NodeType
 from node_cli.utils.print_formatters import print_node_cmd_error
-from node_cli.utils.settings import validate_and_save_node_settings
+from node_cli.utils.settings import save_internal_settings, validate_and_save_node_settings
 from node_cli.utils.texts import safe_load_texts
 from skale_core.settings import get_settings
 
@@ -55,6 +55,7 @@ def init(
     archive: bool = False,
     snapshot: str | None = None,
 ) -> None:
+    save_internal_settings(node_type=NodeType.FAIR, node_mode=node_mode)
     settings = validate_and_save_node_settings(config_file, NodeType.FAIR, node_mode)
     compose_env = compose_node_env(node_type=NodeType.FAIR, node_mode=node_mode)
 
@@ -101,6 +102,7 @@ def update(
     )
     node_mode = upsert_node_mode(node_mode=node_mode)
 
+    save_internal_settings(node_type=NodeType.FAIR, node_mode=node_mode)
     settings = validate_and_save_node_settings(config_file, NodeType.FAIR, node_mode)
     compose_env = compose_node_env(node_type=NodeType.FAIR, node_mode=node_mode)
     update_ok = update_fair_op(


### PR DESCRIPTION
This pull request introduces a consistent step to save internal node settings before validating and saving node settings across various node lifecycle operations. The main change is the addition of calls to `save_internal_settings` in several functions related to node initialization, restoration, migration, and updates, ensuring that internal settings are properly recorded whenever node mode or type changes.

Enhancements to node lifecycle operations:

* Added `save_internal_settings` calls to the `init`, `restore`, `update`, and `migrate_from_boot` functions in `node_cli/fair/active.py`, `node_cli/fair/boot.py`, and `node_cli/fair/common.py` to ensure internal settings are saved before proceeding with node configuration. [[1]](diffhunk://#diff-44e004a3812ad3585e9cb9ce5f66bceab0e3b1238817497a4cdfe52827cf8a4fR70) [[2]](diffhunk://#diff-44e004a3812ad3585e9cb9ce5f66bceab0e3b1238817497a4cdfe52827cf8a4fR147) [[3]](diffhunk://#diff-3734f8a47ef9ee3f354b8d784e490d2f7a205e27a667a6314432269f1ee43c6cR42) [[4]](diffhunk://#diff-3734f8a47ef9ee3f354b8d784e490d2f7a205e27a667a6314432269f1ee43c6cR59) [[5]](diffhunk://#diff-a6b253ee2676f6f2dd5f85aebe05e0504677f9052dee3bde3fca3890d78fa531R58) [[6]](diffhunk://#diff-a6b253ee2676f6f2dd5f85aebe05e0504677f9052dee3bde3fca3890d78fa531R105) [[7]](diffhunk://#diff-cd8b3a0d0a5921ad426729c3dbcd0ae7a148dd6772be2cc807da4316dd166050R180)

Imports and code consistency:

* Updated imports in relevant files to include `save_internal_settings` from `node_cli.utils.settings`, maintaining consistency and enabling the new functionality. [[1]](diffhunk://#diff-44e004a3812ad3585e9cb9ce5f66bceab0e3b1238817497a4cdfe52827cf8a4fL38-R38) [[2]](diffhunk://#diff-3734f8a47ef9ee3f354b8d784e490d2f7a205e27a667a6314432269f1ee43c6cL33-R33) [[3]](diffhunk://#diff-a6b253ee2676f6f2dd5f85aebe05e0504677f9052dee3bde3fca3890d78fa531L41-R41)