### PR TITLE
develop to beta - fix legacy containers

### DIFF
--- a/node_cli/operations/base.py
+++ b/node_cli/operations/base.py
@@ -71,6 +71,7 @@ from node_cli.utils.docker_utils import (
     compose_up,
     docker_cleanup,
     remove_dynamic_containers,
+    rm_legacy_containers,
     system_prune,
 )
 from node_cli.utils.helper import cleanup_dir_content, rm_dir
@@ -123,6 +124,7 @@ def checked_host(func):
 @checked_host
 def update(settings: BaseNodeSettings, compose_env: dict, node_mode: NodeMode) -> bool:
     compose_rm(node_type=NodeType.SKALE, node_mode=node_mode, env=compose_env)
+    rm_legacy_containers()
     remove_dynamic_containers()
 
     sync_skale_node()
@@ -273,6 +275,7 @@ def init_passive(
 
 def update_passive(settings: BaseNodeSettings, compose_env: dict) -> bool:
     compose_rm(env=compose_env, node_type=NodeType.SKALE, node_mode=NodeMode.PASSIVE)
+    rm_legacy_containers()
     remove_dynamic_containers()
     cleanup_volume_artifacts(settings.block_device)
     download_skale_node(settings.node_version, settings.container_configs_dir or None)
@@ -326,6 +329,7 @@ def update_passive(settings: BaseNodeSettings, compose_env: dict) -> bool:
 def turn_off(compose_env: dict, node_type: NodeType, node_mode: NodeMode) -> None:
     logger.info('Turning off the node...')
     compose_rm(env=compose_env, node_type=node_type, node_mode=node_mode)
+    rm_legacy_containers()
     remove_dynamic_containers()
     logger.info('Node was successfully turned off')
 

--- a/node_cli/operations/fair.py
+++ b/node_cli/operations/fair.py
@@ -64,6 +64,7 @@ from node_cli.utils.docker_utils import (
     docker_cleanup,
     is_admin_running,
     remove_dynamic_containers,
+    rm_legacy_containers,
     start_container_by_name,
     stop_container_by_name,
     system_prune,
@@ -201,6 +202,7 @@ def update_fair_boot(
     node_mode: NodeMode = NodeMode.ACTIVE,
 ) -> bool:
     compose_rm(node_type=NodeType.FAIR, node_mode=node_mode, env=compose_env)
+    rm_legacy_containers()
     remove_dynamic_containers()
     cleanup_volume_artifacts(settings.block_device)
 
@@ -260,6 +262,7 @@ def update(
     force_skaled_start: bool,
 ) -> bool:
     compose_rm(node_type=NodeType.FAIR, node_mode=node_mode, env=compose_env)
+    rm_legacy_containers()
     if update_type not in (FairUpdateType.INFRA_ONLY, FairUpdateType.FROM_BOOT):
         remove_dynamic_containers()
 

--- a/node_cli/utils/docker_utils.py
+++ b/node_cli/utils/docker_utils.py
@@ -163,6 +163,11 @@ def remove_telegraf() -> None:
     remove_containers(telegraf, timeout=TELEGRAF_REMOVE_TIMEOUT)
 
 
+def rm_legacy_containers() -> None:
+    containers = docker_client().containers.list(all=True, filters={'name': 'skale_'})
+    remove_containers(containers, timeout=DOCKER_DEFAULT_STOP_TIMEOUT)
+
+
 def remove_containers(containers, timeout):
     for container in containers:
         safe_rm(container, timeout=timeout)

--- a/tests/docker_utils_test.py
+++ b/tests/docker_utils_test.py
@@ -179,7 +179,7 @@ def test_get_all_ima_containers_both_prefixes():
     assert names == {'sk_ima_chain1', 'skale_ima_chain2'}
 
 
-def test_rm_legacy_containers(dclient):
+def test_rm_legacy_containers(dclient, removed_containers_folder):
     names = ['skale_sync_admin', 'skale_api', 'skale_schain_old']
     containers = []
     try:

--- a/tests/docker_utils_test.py
+++ b/tests/docker_utils_test.py
@@ -10,6 +10,7 @@ from node_cli.utils.docker_utils import (
     docker_cleanup,
     get_all_ima_containers,
     get_all_skaled_containers,
+    rm_legacy_containers,
     save_container_logs,
     safe_rm,
 )
@@ -111,6 +112,27 @@ def _make_container(name: str) -> MagicMock:
     return c
 
 
+def test_get_all_skaled_containers_real(dclient):
+    containers = []
+    names = ['sk_skaled_test_chain', 'skale_schain_test_chain']
+    try:
+        for name in names:
+            c = dclient.containers.run('alpine', 'true', name=name, detach=True)
+            containers.append(c)
+        for c in containers:
+            c.wait()
+        result = get_all_skaled_containers()
+        result_names = {c.name for c in result}
+        for name in names:
+            assert name in result_names
+    finally:
+        for c in containers:
+            try:
+                c.remove(force=True)
+            except Exception:
+                pass
+
+
 def test_get_all_skaled_containers_both_prefixes():
     new_container = _make_container('sk_skaled_chain1')
     legacy_container = _make_container('skale_schain_chain2')
@@ -155,3 +177,27 @@ def test_get_all_ima_containers_both_prefixes():
     assert len(result) == 2
     names = {c.name for c in result}
     assert names == {'sk_ima_chain1', 'skale_ima_chain2'}
+
+
+def test_rm_legacy_containers(dclient):
+    names = ['skale_sync_admin', 'skale_api', 'skale_schain_old']
+    containers = []
+    try:
+        for name in names:
+            c = dclient.containers.run('alpine', 'true', name=name, detach=True)
+            containers.append(c)
+        for c in containers:
+            c.wait()
+
+        rm_legacy_containers()
+
+        remaining = dclient.containers.list(all=True, filters={'name': 'skale_'})
+        remaining_names = {c.name for c in remaining}
+        for name in names:
+            assert name not in remaining_names
+    finally:
+        for c in containers:
+            try:
+                c.remove(force=True)
+            except Exception:
+                pass


### PR DESCRIPTION
This pull request introduces a new utility function, `rm_legacy_containers`, to remove legacy Docker containers with names matching the `skale_` prefix. The function is integrated into various node update and shutdown operations to ensure old containers are properly cleaned up. Comprehensive tests are also added to verify the removal logic.

**Container cleanup improvements:**
* Added the `rm_legacy_containers` function in `docker_utils.py`, which removes all containers with names matching the `skale_` prefix.
* Integrated `rm_legacy_containers` into the update and shutdown flows for both SKALE and FAIR nodes in `base.py` and `fair.py`, ensuring legacy containers are removed during these operations. [[1]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653R127) [[2]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653R278) [[3]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653R332) [[4]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cR205) [[5]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cR265)

**Testing enhancements:**
* Added `rm_legacy_containers` to the test imports and implemented `test_rm_legacy_containers` to verify that legacy containers are properly removed. [[1]](diffhunk://#diff-3369c39b709dbc79564167921e05c8788bf5c804e4e99036c57eba069bbce584R13) [[2]](diffhunk://#diff-3369c39b709dbc79564167921e05c8788bf5c804e4e99036c57eba069bbce584R180-R203)
* Added a real Docker test for `get_all_skaled_containers` to validate container discovery logic.

**Code organization:**
* Updated import statements in `base.py` and `fair.py` to include the new utility. [[1]](diffhunk://#diff-ee120515dd175568ad39702495d650fc9593107feee64101ac77176a286eb653R74) [[2]](diffhunk://#diff-704ec423324a49c568ad7ba728601d46cd2ae8e9bf57d050ff1a92d761422f2cR67)